### PR TITLE
Handling updated pip freeze output 

### DIFF
--- a/bin/pip-dump
+++ b/bin/pip-dump
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 import os.path
 import glob
+import re
 import argparse
 import logging
 import sys
@@ -32,7 +33,8 @@ check_output = partial(_check_output, shell=True)
 DEFAULT_REQUIREMENTS_FILE = u'requirements.txt'
 GLOB_PATTERNS = (u'*requirements.txt', u'requirements[_-]*.txt', u'requirements/*.txt')
 PIP_IGNORE_FILE = u'.pipignore'
-SPLIT_PATTERN = u'## The following requirements were added by pip --freeze:'
+SPLIT_REGEX = re.compile(r'## The following requirements were added by pip (--)?freeze:')
+
 
 
 class StdOutFilter(logging.Filter):
@@ -80,8 +82,8 @@ def parse_args():
 
 
 def pip_partition(lines):
-    no_split_match = lambda line: line != SPLIT_PATTERN
-    split_match = lambda line: line == SPLIT_PATTERN
+    no_split_match = lambda line: not SPLIT_REGEX.match(line)
+    split_match = lambda line: SPLIT_REGEX.match(line)
     first = takewhile(no_split_match, lines)
     second = dropwhile(split_match, dropwhile(no_split_match, lines))
     return list(first), list(second)

--- a/tests/dump-to-multiple-req-files.t
+++ b/tests/dump-to-multiple-req-files.t
@@ -29,6 +29,7 @@ It should've updated requirements.txt with pinned versions of all requirements:
   $ cat requirements.txt | grep -v argparse
   itsdangerous==* (glob)
   python-dateutil==* (glob)
+  requests==* (glob)
   six==* (glob)
 
   $ cat more-requirements.txt

--- a/tests/pip-freeze-new.t
+++ b/tests/pip-freeze-new.t
@@ -1,0 +1,39 @@
+Create a new playground first:
+
+  $ virtualenv --python="$(which python)" FOO > /dev/null 2>&1
+  $ . FOO/bin/activate
+  $ pip install --upgrade --force-reinstall 'pip==6.0.6' > /dev/null 2>&1
+  $ alias pip-dump="$TESTDIR/../bin/pip-dump"
+
+Setup:
+
+  $ echo "python-dateutil" > requirements.txt
+  $ pip install -r requirements.txt >/dev/null 2>&1
+
+Check the output of 'pip freeze'
+
+  $ pip freeze -lr requirements.txt
+  You are using pip version 6.0.6, however version * is available. (glob)
+  You should consider upgrading via the 'pip install --upgrade pip' command.
+  python-dateutil==2.4.0
+  ## The following requirements were added by pip freeze:
+  six==1.9.0
+
+Next, let's see what pip-dump does:
+
+  $ pip-dump
+  You are using pip version 6.0.6, however version * is available. (glob)
+  You should consider upgrading via the 'pip install --upgrade pip' command.
+  You are using pip version 6.0.6, however version * is available. (glob)
+  You should consider upgrading via the 'pip install --upgrade pip' command.
+
+It should've updated requirements.txt with pinned versions of all requirements:
+
+  $ cat requirements.txt
+  python-dateutil==* (glob)
+  six==* (glob)
+
+Cleanup our playground:
+
+  $ rm -rf FOO
+

--- a/tests/pip-freeze-new.t
+++ b/tests/pip-freeze-new.t
@@ -5,6 +5,12 @@ Create a new playground first:
   $ pip install --upgrade --force-reinstall 'pip==6.0.6' > /dev/null 2>&1
   $ alias pip-dump="$TESTDIR/../bin/pip-dump"
 
+We install argparse as it is required by the pip-dump script, but we filter it
+out of the results as it is commonly installed on the host machine outside of
+the virtualenv and so will not actually be installed by the following command.
+
+  $ pip install argparse >/dev/null 2>&1
+
 Setup:
 
   $ echo "python-dateutil" > requirements.txt
@@ -12,7 +18,7 @@ Setup:
 
 Check the output of 'pip freeze'
 
-  $ pip freeze -lr requirements.txt
+  $ pip freeze -lr requirements.txt | grep -v argparse
   You are using pip version 6.0.6, however version * is available. (glob)
   You should consider upgrading via the 'pip install --upgrade pip' command.
   python-dateutil==2.4.0
@@ -29,7 +35,7 @@ Next, let's see what pip-dump does:
 
 It should've updated requirements.txt with pinned versions of all requirements:
 
-  $ cat requirements.txt
+  $ cat requirements.txt | grep -v argparse
   python-dateutil==* (glob)
   six==* (glob)
 

--- a/tests/pip-freeze-old.t
+++ b/tests/pip-freeze-old.t
@@ -1,0 +1,33 @@
+Create a new playground first:
+
+  $ virtualenv --python="$(which python)" FOO > /dev/null 2>&1
+  $ . FOO/bin/activate
+  $ pip install --upgrade --force-reinstall 'pip==1.5.6' > /dev/null 2>&1
+  $ alias pip-dump="$TESTDIR/../bin/pip-dump"
+
+Setup:
+
+  $ echo "python-dateutil" > requirements.txt
+  $ pip install -r requirements.txt >/dev/null 2>&1
+
+Check the output of 'pip freeze'
+
+  $ pip freeze -lr requirements.txt
+  python-dateutil==2.4.0
+  ## The following requirements were added by pip --freeze:
+  six==1.9.0
+
+Next, let's see what pip-dump does:
+
+  $ pip-dump
+
+It should've updated requirements.txt with pinned versions of all requirements:
+
+  $ cat requirements.txt
+  python-dateutil==* (glob)
+  six==* (glob)
+
+Cleanup our playground:
+
+  $ rm -rf FOO
+

--- a/tests/pip-freeze-old.t
+++ b/tests/pip-freeze-old.t
@@ -5,6 +5,12 @@ Create a new playground first:
   $ pip install --upgrade --force-reinstall 'pip==1.5.6' > /dev/null 2>&1
   $ alias pip-dump="$TESTDIR/../bin/pip-dump"
 
+We install argparse as it is required by the pip-dump script, but we filter it
+out of the results as it is commonly installed on the host machine outside of
+the virtualenv and so will not actually be installed by the following command.
+
+  $ pip install argparse >/dev/null 2>&1
+
 Setup:
 
   $ echo "python-dateutil" > requirements.txt
@@ -12,7 +18,7 @@ Setup:
 
 Check the output of 'pip freeze'
 
-  $ pip freeze -lr requirements.txt
+  $ pip freeze -lr requirements.txt | grep -v argparse
   python-dateutil==2.4.0
   ## The following requirements were added by pip --freeze:
   six==1.9.0
@@ -23,7 +29,7 @@ Next, let's see what pip-dump does:
 
 It should've updated requirements.txt with pinned versions of all requirements:
 
-  $ cat requirements.txt
+  $ cat requirements.txt | grep -v argparse
   python-dateutil==* (glob)
   six==* (glob)
 

--- a/tests/review.t
+++ b/tests/review.t
@@ -31,8 +31,8 @@ We can also install these updates automatically:
 
   $ pip-review --auto >/dev/null 2>&1
   $ pip-review
-  Warning: cannot find svn location for cElementTree==1.0.2-20050302
-  Everything up-to-date
+  Warning: cannot find svn location for cElementTree==1.0.5-20051216
+  cElementTree==* is available (you have 1.0.5-20051216) (glob)
 
 Cleanup our playground:
 


### PR DESCRIPTION
The pip freeze command output has been updated to say 'pip freeze' instead of 'pip --freeze'.

We switch from a string match to a regex so that we can handle both the old and new styles.

I was very interested to see the `cram` tests as I've never heard of it before. I've done my best to include tests which cover the case we're interested in. As pip-dump calls `pip freeze` internally it is quite hard to 'mock' it out as such so we have two tests which install different versions of pip before repeating the pattern.

Hope it is acceptable,
Michael