### PR TITLE
Extract wheel dependencies from metadata.json as well

### DIFF
--- a/piptools/package_manager.py
+++ b/piptools/package_manager.py
@@ -510,7 +510,8 @@ class PackageManager(BasePackageManager):
                     self.unpack_archive(path, unpack_dir)
 
                     # first, check if archive was a wheel
-                    name = find_file(unpack_dir, 'pydist.json')
+                    name = (find_file(unpack_dir, 'pydist.json') or
+                            find_file(unpack_dir, 'metadata.json'))
                     if name:
                         deps = self.read_wheel_requires(name)
                     else:


### PR DESCRIPTION
I'm failing to extract dependencies from wheels that have theirs
packaged in a metadata.json instead of a pydist.json.  This updates
extract_dependencies() to also check for a metadata.json.