### PR TITLE
Add log entry for dependency cache being used (+location)

### DIFF
--- a/piptools/package_manager.py
+++ b/piptools/package_manager.py
@@ -234,6 +234,7 @@ class PackageManager(BasePackageManager):
         if not os.path.exists(self.download_cache_root):
             os.makedirs(self.download_cache_root)
         self._link_cache = {}
+        logger.debug('Using dependency cache from {0}.'.format(self.dep_cache_file))
         self._dep_cache = PersistentCache(self.dep_cache_file)
         self._dep_call_cache = {}
         self._best_match_call_cache = {}


### PR DESCRIPTION
I had an issue where the caches appeared to not resolve to the same
dependencies, and finding out (from the source) that there's an ondisk
cache helped me to resolve it (by removing the caches).