### PR TITLE
Fix logger handling with pip < 6

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -37,20 +37,19 @@ def setup_logging(verbose):
     logger.addHandler(handler)
     logger.setLevel(level)
 
-    try:
-        from pip import logger as pip_logger
-    except ImportError:
-        # Old method, removed in 767d11e (tags/6.0~104^2).
-        from pip.log import logger as pip_logger
-        pip_logger.consumers.append(
-            (pip_logger.VERBOSE_DEBUG,
-             lambda msg: logger.debug('PIP said: ' + msg)))
-    else:
+    from pip import logger as pip_logger
+    if hasattr(pip_logger, 'addHandler'):
+        # New method from pip 6 onwards.
         pip_formatter = logging.Formatter('PIP said: %(message)s', None)
         pip_handler = logging.StreamHandler()
         pip_handler.setFormatter(pip_formatter)
         pip_handler.setLevel(level)
         pip_logger.addHandler(pip_handler)
+    else:
+        # Old method, removed in 767d11e (tags/6.0~104^2).
+        pip_logger.consumers.append(
+            (pip_logger.VERBOSE_DEBUG,
+             lambda msg: logger.debug('PIP said: ' + msg)))
 
 
 def walk_specfile(filename):


### PR DESCRIPTION
This is a followup to 6d0fbec, which broke it for pip 1.5.6.