### PR TITLE
Add pre-release logic

### DIFF
--- a/bin/pip-review
+++ b/bin/pip-review
@@ -11,7 +11,7 @@ try:
     import urllib2 as urllib_request  # Python2
 except ImportError:
     import urllib.request as urllib_request
-from pkg_resources import parse_version
+from packaging.version import parse
 
 try:
     from subprocess import check_output as _check_output
@@ -61,6 +61,9 @@ def parse_args():
         '--local', '-l', action='store_true', default=False,
         help='If in a virtualenv that has global access, do not output '
              'globally-installed packages')
+    parser.add_argument(
+        '--pre', action='store_true', default=False,
+        help='Also include pre-release versions of packages')
     return parser.parse_args()
 
 
@@ -112,7 +115,7 @@ def get_pkg_info(pkg_name, silent=False):
     return info
 
 
-def latest_version(pkg_name, silent=False):
+def latest_version(pkg_name, silent=False, pre=False):
     try:
         info = get_pkg_info(pkg_name, silent=silent)
     except ValueError:
@@ -122,12 +125,16 @@ def latest_version(pkg_name, silent=False):
             raise
     if not info:
         return None, None
-    version = info['info']['version']
-    return parse_version(version), version
+
+    releases = sorted(map(parse, info['releases'].keys()))
+    if not pre:
+        releases = filter(lambda v: not v.is_prerelease, releases)
+
+    return releases[-1], releases[-1].public
 
 
-def get_latest_versions(pkg_names):
-    get_latest = partial(latest_version, silent=True)
+def get_latest_versions(pkg_names, pre=False):
+    get_latest = partial(latest_version, silent=True, pre=pre)
     versions = map(get_latest, pkg_names)
     return zip(pkg_names, versions)
 
@@ -151,7 +158,7 @@ def get_installed_pkgs(local=False):
             yield name, 'dev', 'dev', True
         else:
             name, version = line.split('==')
-            yield name, parse_version(version), version, False
+            yield name, parse(version), version, False
 
 
 class StdOutFilter(logging.Filter):
@@ -235,7 +242,7 @@ def main():
     installed = list(get_installed_pkgs(local=args.local))
     lookup_on_pypi = [name for name, _, _, editable in installed
                       if not editable or args.editables]
-    latest_versions = dict(get_latest_versions(lookup_on_pypi))
+    latest_versions = dict(get_latest_versions(lookup_on_pypi, pre=args.pre))
 
     all_ok = True
     for pkg, installed_raw_version, installed_version, editable in installed:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 def get_dependencies():
-    deps = []
+    deps = ['packaging']
     if sys.version_info < (2, 7):
         deps += ['argparse']
     return deps


### PR DESCRIPTION
Add a command line flag (`--pre`) to enable pre-releases which are disabled by default. See #135.