### PR TITLE
future: re-add support for non-editable VCS urls; fix pinning

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -13,6 +13,9 @@ class BaseRepository(object):
     def clear_caches(self):
         """Should clear any caches used by the implementation."""
 
+    def freshen_build_caches(self):
+        """Should start with fresh build/source caches."""
+
     @abstractmethod
     def find_best_match(self, ireq):
         """

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -41,6 +41,9 @@ class PyPIRepository(BaseRepository):
         # project
         self._available_versions_cache = {}
 
+        # Cache for get_dependencies.
+        self._get_dependencies_cache = {}
+
         # Setup file paths
         self.freshen_build_caches()
         self._download_dir = os.path.expanduser('~/.pip-tools/pkgs')
@@ -99,6 +102,10 @@ class PyPIRepository(BaseRepository):
         dependencies (also InstallRequirements, but not necessarily pinned).
         They indicate the secondary dependencies for the given requirement.
         """
+
+        if ireq in self._get_dependencies_cache:
+            return self._get_dependencies_cache[ireq]
+
         if not os.path.isdir(self._download_dir):
             os.makedirs(self._download_dir)
         if not os.path.isdir(self._wheel_download_dir):
@@ -116,4 +123,5 @@ class PyPIRepository(BaseRepository):
                                 ignore_installed=True,
                                 session=self.session)
         dependencies = reqset._prepare_file(self.finder, ireq)
-        return set(dependencies)
+        self._get_dependencies_cache[ireq] = set(dependencies)
+        return self._get_dependencies_cache[ireq]

--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -49,11 +49,21 @@ class PyPIRepository(BaseRepository):
         self._download_dir = os.path.expanduser('~/.pip-tools/pkgs')
         self._wheel_download_dir = os.path.expanduser('~/.pip-tools/wheels')
 
+        # References to old build dirs (to prevent too early pruning).
+        self._old_build_dirs = []
+
     def freshen_build_caches(self):
         """
         Start with fresh build/source caches.  Will remove any old build
         caches from disk automatically.
         """
+        # Keep old build dirs around: they are required by
+        # format_requirement/get_src_requirement.
+        if hasattr(self, '_build_dir'):
+            self._old_build_dirs.append(self._build_dir)
+        if hasattr(self, '_source_dir'):
+            self._old_build_dirs.append(self._source_dir)
+
         self._build_dir = TemporaryDirectory('build')
         self._source_dir = TemporaryDirectory('source')
 

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -9,6 +9,7 @@ from itertools import chain, count
 import click
 from first import first
 from pip.req import InstallRequirement
+from pip.vcs import vcs
 
 from .cache import DependencyCache
 from .exceptions import UnsupportedConstraint
@@ -87,14 +88,17 @@ class Resolver(object):
 
     def _check_constraints(self):
         for constraint in chain(self.our_constraints, self.their_constraints):
-            if constraint.link is not None and not constraint.editable:
-                msg = ('pip-compile does not support URLs as packages, unless they are editable '
-                       '(perhaps add -e option?)')
-                raise UnsupportedConstraint(msg)
+            if constraint.link and constraint.link.scheme not in vcs.all_schemes:
+                msg = ('pip-compile does not support artifact URLs as packages'
+                       ' (but you can use VCS URLs).')
             elif constraint.extras:
                 msg = ('pip-compile does not yet support packages with extras. '
                        'Support for this is in the works, though.')
-                raise UnsupportedConstraint(msg)
+            else:
+                continue
+
+            msg += ' Constraint: {0}.'.format(str(constraint))
+            raise UnsupportedConstraint(msg)
 
     def _group_constraints(self, constraints):
         """
@@ -185,11 +189,7 @@ class Resolver(object):
             Flask==0.10.1 => Flask==0.10.1
 
         """
-        if ireq.editable:
-            # NOTE: it's much quicker to immediately return instead of
-            # hitting the index server
-            best_match = ireq
-        elif is_pinned_requirement(ireq):
+        if ireq.editable or ireq.link or is_pinned_requirement(ireq):
             # NOTE: it's much quicker to immediately return instead of
             # hitting the index server
             best_match = ireq
@@ -210,12 +210,12 @@ class Resolver(object):
         Editable requirements will never be looked up, as they may have
         changed at any time.
         """
-        if ireq.editable:
+        if ireq.editable or ireq.link:
             for dependency in self.repository.get_dependencies(ireq):
                 yield dependency
             return
         elif not is_pinned_requirement(ireq):
-            raise TypeError('Expected pinned or editable requirement, got {}'.format(ireq))
+            raise TypeError('Expected pinned or editable requirement, or link, got {}'.format(ireq))
 
         # Now, either get the dependencies from the dependency cache (for
         # speed), or reach out to the external repository to
@@ -236,5 +236,6 @@ class Resolver(object):
             yield InstallRequirement.from_line(dependency_string)
 
     def reverse_dependencies(self, ireqs):
-        tups = (as_name_version_tuple(ireq) for ireq in ireqs if not ireq.editable)
+        tups = (as_name_version_tuple(ireq) for ireq in ireqs
+                if not (ireq.editable or ireq.link))
         return self.dependency_cache.reverse_dependencies(tups)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,18 +8,10 @@ def test_format_requirement(from_line):
     ireq = from_line('test==1.2')
     assert format_requirement(ireq) == 'test==1.2'
 
-    # Annotations are printed as comments at a fixed column
-    assert (format_requirement(ireq, annotation='xyz') ==
-            'test==1.2                 # xyz')
-
 
 def test_format_requirement_editable(from_editable):
     ireq = from_editable('git+git://fake.org/x/y.git#egg=y')
     assert format_requirement(ireq) == '-e git+git://fake.org/x/y.git#egg=y'
-
-    # Annotations are printed as comments at a fixed column
-    assert (format_requirement(ireq, annotation='xyz') ==
-            '-e git+git://fake.org/x/y.git#egg=y  # xyz')
 
 
 def test_format_specifier(from_line):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,42 @@
+from pytest import fixture
+
+from piptools.utils import comment
+from piptools.writer import OutputWriter
+
+
+@fixture
+def writer():
+    return OutputWriter(src_file="src_file", dry_run=True, header=True,
+                        annotate=True, default_index_url=None, index_urls=[])
+
+
+def test_format_requirement_annotation_editable(from_editable, writer):
+    # Annotations are printed as comments at a fixed column
+    ireq = from_editable('git+git://fake.org/x/y.git#egg=y')
+    reverse_dependencies = {'y': ['xyz']}
+
+    assert (writer._format_requirement(ireq,
+                                       reverse_dependencies,
+                                       primary_packages=[]) ==
+            '-e git+git://fake.org/x/y.git#egg=y' + comment('  # via xyz'))
+
+
+def test_format_requirement_annotation(from_line, writer):
+    ireq = from_line('test==1.2')
+    reverse_dependencies = {'test': ['xyz']}
+
+    assert (writer._format_requirement(ireq,
+                                       reverse_dependencies,
+                                       primary_packages=[]) ==
+            'test==1.2               ' + comment('  # via xyz'))
+
+
+def test_format_requirement_not_for_primary(from_line, writer):
+    "Primary packages should not get annotated."
+    ireq = from_line('test==1.2')
+    reverse_dependencies = {'test': ['xyz']}
+
+    assert (writer._format_requirement(ireq,
+                                       reverse_dependencies,
+                                       primary_packages=['test']) ==
+            'test==1.2')


### PR DESCRIPTION
This allows for regular/non-editable VCS URLs again, and will pip them
to the current commit.  This gets now done for editable VCS URLs, too.

(This includes #167 to fix the existing tests, and #160 + #158)