### PR TITLE
Fix missing transitive dependencies.

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -165,9 +165,8 @@ class Resolver(object):
             for new_dependency in sorted(diff, key=lambda req: req.key):
                 log.debug('  adding {}'.format(new_dependency))
 
-        # Store the last round's results in the their_constraints set
-        # (overriding what was in there)
-        self.their_constraints = theirs
+        # Store the last round's results in the their_constraints
+        self.their_constraints |= theirs
         return has_changed, best_matches
 
     def get_best_match(self, ireq):


### PR DESCRIPTION
Currently, each set of discovered dependencies get's thrown away, this means that if you have 3 or more "levels" of dependencies like foo depends on bar, depends on frob, then you will end up with a list that contains only bar (because it is in our constraint) and frob (because we threw away bar). This will make it so that we don't throw away constraints.