### PR TITLE
Prereleases treat None and False differently

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -71,7 +71,7 @@ class PyPIRepository(BaseRepository):
             self._available_versions_cache[req_name] = self.finder._find_all_versions(req_name)
         return self._available_versions_cache[req_name]
 
-    def find_best_match(self, ireq, prereleases=False):
+    def find_best_match(self, ireq, prereleases=None):
         """
         Returns a Version object that indicates the best match for the given
         InstallRequirement according to the external repository.

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -26,7 +26,7 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.in'
 @click.command()
 @click.option('-v', '--verbose', is_flag=True, help="Show more output")
 @click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
-@click.option('-p', '--pre', is_flag=True, help="Allow resolving to prereleases (default is not)")
+@click.option('-p', '--pre', is_flag=True, default=None, help="Allow resolving to prereleases (default is not)")
 @click.option('-r', '--rebuild', is_flag=True, help="Clear any caches upfront, rebuild from scratch")
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page")
 @click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)")


### PR DESCRIPTION
The packaging library treats ``False`` and ``None`` differently for prereleases, ``False`` means "never ever allow a prereleases" and ``None`` means "allow one if it's the only thing available OR if a specifier opts into it". The ``None`` behavior is the default behavior of pip, the packaging library and the recommended mode by PEP 440.

This makes it so that something like ``Pyramid>=1.6a2`` doesn't fail without a ``--pre``.