### PR TITLE
Implement pip-sync

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -13,7 +13,35 @@ if not tuple(int(digit) for digit in pip.__version__.split('.')[:2]) >= (6, 1):
           'perhaps run `pip install --upgrade pip`?'.format(pip.__version__))
     sys.exit(4)
 
+from .. import sync
+
+DEFAULT_REQUIREMENTS_FILE='requirements.txt'
 
 @click.command()
-def cli():
-    click.echo('TODO: Implement')
+@click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
+@click.argument('src_file', required=False, type=click.Path(exists=True), default=DEFAULT_REQUIREMENTS_FILE)
+def cli(dry_run, src_file):
+    requirements = pip.req.parse_requirements(src_file, session=True)
+    installed = pip.get_installed_distributions()
+
+    to_be_installed, to_be_uninstalled = sync.diff(requirements, installed)
+
+    if not dry_run:
+        sync.sync(to_be_installed, to_be_uninstalled, verbose=True)
+    else:
+        show_dry_run(to_be_installed, to_be_uninstalled)
+
+
+def show_dry_run(to_be_installed, to_be_uninstalled):
+    if not to_be_uninstalled and not to_be_installed:
+        print("Everything up-to-date")
+
+    if to_be_uninstalled:
+        print("Would uninstall:")
+        for module in to_be_uninstalled:
+            print("  {}".format(module))
+
+    if to_be_installed:
+        print("Would install:")
+        for module in to_be_installed:
+            print("  {}".format(module))

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -22,7 +22,7 @@ def diff(requirements, installed):
             pass
         elif key not in requirements:
             to_be_uninstalled.add(module.as_requirement())
-        elif module.version in requirements[key].specifier:
+        elif requirements[key].specifier.contains(module.version):
             satisfied.add(key)
 
     for key, requirement in requirements.items():

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -1,0 +1,50 @@
+import pip
+
+exceptions = ['pip', 'setuptools', 'wheel']
+
+def diff(requirements, installed):
+    """
+    Calculate which modules should be installed or uninstalled,
+    given a set of requirements and a list of installed modules.
+    """
+
+    requirements = { r.req.key: r for r in requirements }
+
+    to_be_installed = set()
+    to_be_uninstalled = set()
+
+    satisfied = set()
+
+    for module in installed:
+        key = module.key
+
+        if key in exceptions:
+            pass
+        elif key not in requirements:
+            to_be_uninstalled.add(module.as_requirement())
+        elif module.version in requirements[key].specifier:
+            satisfied.add(key)
+
+    for key, requirement in requirements.items():
+        if key not in satisfied:
+            to_be_installed.add(requirement.req)
+
+    return (to_be_installed, to_be_uninstalled)
+
+
+def sync(to_be_installed, to_be_uninstalled, verbose=False):
+    """
+    Install and uninstalls the given sets of modules.
+    """
+
+    flags = []
+
+    if not verbose:
+        flags.append('-q')
+
+    if to_be_uninstalled:
+        flags.append('-y')
+        pip.main(["uninstall"] + flags + [str(req) for req in to_be_uninstalled])
+
+    if to_be_installed:
+        pip.main(["install"] + flags + [str(req) for req in to_be_installed])

--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -43,8 +43,7 @@ def sync(to_be_installed, to_be_uninstalled, verbose=False):
         flags.append('-q')
 
     if to_be_uninstalled:
-        flags.append('-y')
-        pip.main(["uninstall"] + flags + [str(req) for req in to_be_uninstalled])
+        pip.main(["uninstall", '-y'] + flags + [str(req) for req in to_be_uninstalled])
 
     if to_be_installed:
         pip.main(["install"] + flags + [str(req) for req in to_be_installed])

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'pip-compile = piptools.scripts.compile:cli',
-            # 'pip-sync = piptools.scripts.sync:cli',  # TODO
+            'pip-sync = piptools.scripts.sync:cli',
         ],
     },
     platforms='any',


### PR DESCRIPTION
I implemented `pip-sync`. It would be nice to have this available, so if there's anything you'd like me to do in order to get this merged, let me know.

Here's an overview of what it does:

1. Parse `requirements.txt` using `pip.req.parse_requirements`
2. Fetch currently installed modules using `pip.get_installed_distributions`
3. Diff these two sets, by module name and version specifier
4. install and uninstall the resulting modules using `pip.main(["(un)install"] + ...)`

I had to create a whitelist to avoid uninstalling the following modules, which are automatically installed when creating a virtualenv and not listed on requirements.txt:
- pip
- wheel
- setuptools

I am assuming that `requirements.txt` contains all direct and indirect dependencies, as if it was generated by `pip-compile`, so if an indirect dependency is not present, it will be uninstalled and installed again.