### PR TITLE
Strip '\r' in the output of pip for Windows platform

### DIFF
--- a/bin/pip-review
+++ b/bin/pip-review
@@ -143,6 +143,7 @@ def get_installed_pkgs(local=False):
     for line in output.split('\n'):
         if not line or line.startswith('##'):
             continue
+        line = line.rstrip('\r')
 
         if line.startswith('-e'):
             name = line.split('#egg=', 1)[1]


### PR DESCRIPTION
In Windows, pip-reivew remove '\n' but not '\r'. So output message is broken as below.

> D:\>python pip-review
> )eautifulsoup4==4.4.0 is available (you have 4.3.2
> )lick==4.1 is available (you have 4.0
> )ryptography==0.9.3 is available (you have 0.9.1

This patch remove trailing '\r' from the output of pip.