### PR TITLE
Accept env variables for pip-inspired options

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -28,9 +28,9 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.in'
 @click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
 @click.option('-p', '--pre', is_flag=True, default=None, help="Allow resolving to prereleases (default is not)")
 @click.option('-r', '--rebuild', is_flag=True, help="Clear any caches upfront, rebuild from scratch")
-@click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page")
-@click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)")
-@click.option('--extra-index-url', multiple=True, help="Add additional index URL to search")
+@click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')
+@click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)", envvar='PIP_INDEX_URL')
+@click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')
 @click.option('--header/--no-header', is_flag=True, default=True, help="Add header to generated file")
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")


### PR DESCRIPTION
pip allows passing options as environment variables [0]. pip-tools has
three pip-inspired options: passing envvar to `@click.option` allows to
accept those environment variables too. click also supports
`auto_envvar_prefrix` [1], but this would apply to all options, not only
pip-inspired options.

[0] https://pip.pypa.io/en/stable/user_guide.html#environment-variables
[1] http://click.pocoo.org/4/options/#values-from-environment-variables