### PR TITLE
Enables multiple requirements and processes whitelist dependencies

### DIFF
--- a/piptools/exceptions.py
+++ b/piptools/exceptions.py
@@ -24,3 +24,12 @@ class UnsupportedConstraint(PipToolsError):
     def __str__(self):
         message = super(UnsupportedConstraint, self).__str__()
         return '{} (constraint was: {})'.format(message, str(self.constraint))
+
+class IncompatibleRequirements(PipToolsError):
+    def __init__(self, ireq_a, ireq_b):
+        self.ireq_a = ireq_a
+        self.ireq_b = ireq_b
+
+    def __str__(self):
+        message = "Incompatible requirements found: {} and {}"
+        return message.format(self.ireq_a, self.ireq_b)

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -23,8 +23,10 @@ DEFAULT_REQUIREMENTS_FILE='requirements.txt'
 @click.command()
 @click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
 @click.option('--force', is_flag=True, help="Proceed even if conflicts are found")
-@click.argument('src_files', required=False, type=click.Path(exists=True), default=DEFAULT_REQUIREMENTS_FILE, nargs=-1)
+@click.argument('src_files', required=False, type=click.Path(exists=True), default=(DEFAULT_REQUIREMENTS_FILE,), nargs=-1)
 def cli(dry_run, force, src_files):
+    if not src_files:
+        src_files = (DEFAULT_REQUIREMENTS_FILE,)
 
     requirements = flat_map(
             lambda src: pip.req.parse_requirements(src, session=True),

--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from itertools import groupby
+from itertools import groupby, chain
 
 from click import style
 from first import first
@@ -78,6 +78,10 @@ def as_name_version_tuple(ireq):
 def full_groupby(iterable, key=None):
     """Like groupby(), but sorts the input on the group key first."""
     return groupby(sorted(iterable, key=key), key=key)
+
+def flat_map(fn, collection):
+    """Map a function over a collection and flatten the result by one-level"""
+    return chain.from_iterable(map(fn, collection))
 
 
 def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 from functools import partial
 
 from pip._vendor.packaging.version import Version
+from pip._vendor.pkg_resources import Requirement
 from pip.req import InstallRequirement
 from pytest import fixture
 
@@ -35,6 +36,24 @@ class FakeRepository(BaseRepository):
         dependencies = self.index[name][version]
         return [InstallRequirement.from_line(dep) for dep in dependencies]
 
+
+class FakeInstalledDistribution(object):
+    def __init__(self, line, deps):
+        self.deps = [Requirement.parse(d) for d in deps]
+
+        self.req = Requirement.parse(line)
+
+        self.key = self.req.key
+        self.specifier = self.req.specifier
+
+        self.version = line.split("==")[1]
+
+    def requires(self):
+        return self.deps
+
+@fixture
+def installed_distribution():
+    return FakeInstalledDistribution
 
 @fixture
 def repository():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,8 @@
 import pytest
 
-from piptools.sync import (dependency_tree)
+from piptools.sync import (dependency_tree, merge)
+from piptools.exceptions import IncompatibleRequirements
+from collections import Counter
 
 
 @pytest.mark.parametrize(
@@ -46,3 +48,25 @@ def test_dependency_tree(installed_distribution, installed, root, expected):
 
     actual = dependency_tree(installed, root)
     assert actual == set(expected)
+
+
+def test_merge_detect_conflicts(from_line):
+    requirements = [from_line('flask==1'), from_line('flask==2')]
+
+    with pytest.raises(IncompatibleRequirements):
+        merge(requirements, ignore_conflicts=False)
+
+
+def test_merge_ignore_conflicts(from_line):
+    requirements = [from_line('flask==1'), from_line('flask==2')]
+
+    assert Counter(requirements[1:2]) == Counter(merge(requirements, ignore_conflicts=True))
+
+
+def test_merge(from_line):
+    requirements = [
+            from_line('flask==1'),
+            from_line('flask==1'),
+            from_line('django==2')]
+
+    assert Counter(requirements[1:3]) == Counter(merge(requirements, ignore_conflicts=True))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,48 @@
+import pytest
+
+from piptools.sync import (dependency_tree)
+
+
+@pytest.mark.parametrize(
+    ('installed', 'root', 'expected'),
+
+    [
+        ([],
+            'pip-tools', []),
+
+        ([('pip-tools==1', [])],
+            'pip-tools', ['pip-tools']),
+
+        ([('pip-tools==1', []),
+          ('django==1.7', [])],
+            'pip-tools', ['pip-tools']),
+
+        ([('pip-tools==1', ['click>=2']),
+          ('django==1.7', []),
+          ('click==3', [])],
+            'pip-tools', ['pip-tools', 'click']),
+
+        ([('pip-tools==1', ['click>=2']),
+          ('django==1.7', []),
+          ('click==1', [])],
+            'pip-tools', ['pip-tools']),
+
+        ([('root==1', ['child==2']),
+          ('child==2', ['grandchild==3']),
+          ('grandchild==3', [])],
+            'root', ['root', 'child', 'grandchild']),
+
+        ([('root==1', ['child==2']),
+          ('child==2', ['root==1'])],
+            'root', ['root', 'child']),
+    ]
+)
+def test_dependency_tree(installed_distribution, installed, root, expected):
+    installed = {
+            distribution.key: distribution
+            for distribution in (
+                installed_distribution(name, deps)
+                for name, deps in installed ) }
+
+    actual = dependency_tree(installed, root)
+    assert actual == set(expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from pytest import raises
 
 from piptools.utils import (as_name_version_tuple, format_requirement,
-                            format_specifier)
+                            format_specifier, flat_map)
 
 
 def test_format_requirement(from_line):
@@ -43,3 +43,6 @@ def test_as_name_version_tuple(from_line):
         ireq = from_line(spec)
         with raises(TypeError):
             as_name_version_tuple(ireq)
+
+def test_flat_map():
+    assert [1,2,4,1,3,9] == list(flat_map(lambda x: [1,x,x*x], [2,3]))


### PR DESCRIPTION
Fixes #183 
- Whitelist dependencies of whitelisted modules
- Enable multiple requirements files in pip-sync