### PR TITLE
Copy 'mising -e' error from compile to sync

### DIFF
--- a/piptools/sync.py
+++ b/piptools/sync.py
@@ -3,7 +3,7 @@ import collections
 from . import click
 import pip
 
-from .exceptions import IncompatibleRequirements
+from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import flat_map
 
 PACKAGES_TO_IGNORE = [
@@ -65,6 +65,11 @@ def merge(requirements, ignore_conflicts):
     by_key = {}
 
     for ireq in requirements:
+        if ireq.link is not None and not ireq.editable:
+            msg = ('pip-compile does not support URLs as packages, unless they are editable. '
+                   'Perhaps add -e option?')
+            raise UnsupportedConstraint(msg, ireq)
+
         key = ireq.req.key
 
         if not ignore_conflicts:


### PR DESCRIPTION
Not sure if this is the best way to do it? But the `AttributeError` that I was getting before was not really informative. Thanks!