### PR TITLE
Honor pip's pip.conf (or pip.ini on Windows).

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -23,19 +23,30 @@ except ImportError:
 
 class PyPIRepository(BaseRepository):
     DEFAULT_INDEX_URL = 'https://pypi.python.org/simple/'
-
+    
     """
     The PyPIRepository will use the provided Finder instance to lookup
     packages.  Typically, it looks up packages on PyPI (the default implicit
     config), but any other PyPI mirror can be used if index_urls is
     changed/configured on the Finder.
     """
-    def __init__(self):
+    def __init__(self, pip_options):
         self.session = PipSession()
-        self.finder = PackageFinder(find_links=[],
-                                    index_urls=[self.DEFAULT_INDEX_URL],
-                                    session=self.session)
 
+        index_urls = [pip_options.index_url] + pip_options.extra_index_urls
+        if pip_options.no_index:
+            logger.info('Ignoring indexes: %s', ','.join(index_urls))
+            index_urls = []
+
+        self.finder = PackageFinder(
+            find_links=pip_options.find_links,
+            index_urls=index_urls,
+            trusted_hosts=pip_options.trusted_hosts,
+            allow_all_prereleases=pip_options.pre,
+            process_dependency_links=pip_options.process_dependency_links,
+            session=self.session,
+        )
+        
         # Caches
         # stores project_name => InstallationCandidate mappings for all
         # versions reported by PyPI, so we only have to ask once for each

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+import pytest
+
+from click.testing import CliRunner
+from piptools.scripts.compile import cli
+
+@pytest.fixture
+def pip_conf(request):
+    test_conf = """
+[global]
+index-url = http://example.com
+trusted-host = example.com
+    """
+    #write pip.conf (pip.ini) at root of virtualenv
+    pip_conf_file = 'pip.conf' if os.name != 'nt' else 'pip.ini'
+    pip_conf_file = os.path.join(sys.prefix, pip_conf_file)
+    with open(pip_conf_file, 'w') as pip_conf:
+        pip_conf.write(test_conf)
+    
+    def tear_down():
+        os.remove(pip_conf_file)
+
+    request.addfinalizer(tear_down)
+    
+    return pip_conf_file
+
+
+def test_default_pip_conf_read(pip_conf):
+
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # preconditions
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['-v'])
+
+        # check that we have our index-url as specified in pip.conf
+        assert 'Using indexes:\n  http://example.com' in out.output
+        assert '--index-url http://example.com' in out.output
+
+
+def test_command_line_overrides_pip_conf(pip_conf):
+
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # preconditions
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['-v', '-i', 'http://override.com'])
+
+        # check that we have our index-url as specified in pip.conf
+        assert 'Using indexes:\n  http://override.com' in out.output


### PR DESCRIPTION
This ground work allows specifying sensible defaults in pip.conf for things like trusted-host, isolated index-url, etc.

The strategy is to use the pip OptionParser to honor the defaults (which supports pip.conf).

We then translate click options to pip options which are used to instantiate the PackageFinder.

Fixes #199