### PR TITLE
remove __future__ unicode import to allow non unicode os.environ keys

### DIFF
--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -1,6 +1,5 @@
 # coding: utf-8
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import os
 from functools import partial


### PR DESCRIPTION
Fixes #209

Using unicode_literals as \_\_future\_\_ breaks os.environ on python 2.7, when used in subprocess invocations (that forward the env) which does not allow unicode data.

As this module uses os.environ['PIP_EXISTS_ACTION'] = 'i' and pip copies this in a subprocess call, it breaks with this stack trace (actual path root removed from output):

```
  File "pip-tools-venv\lib\site-packages\piptools\scripts\compile.py", line 108, in cli
    results = resolver.resolve()
  File "pip-tools-venv\lib\site-packages\piptools\resolver.py", line 78, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "pip-tools-venv\lib\site-packages\piptools\resolver.py", line 162, in _resolve_one_round
    for best_match in best_matches
  File "pip-tools-venv\lib\site-packages\piptools\resolver.py", line 163, in <genexpr>
    for dep in self._iter_dependencies(best_match))
  File "pip-tools-venv\lib\site-packages\piptools\resolver.py", line 234, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "pip-tools-venv\lib\site-packages\piptools\repositories\pypi.py", line 127, in get_dependencies
    dependencies = reqset._prepare_file(self.finder, ireq)
  File "pip-tools-venv\lib\site-packages\pip\req\req_set.py", line 505, in _prepare_file
    abstract_dist.prep_for_dist()
  File "pip-tools-venv\lib\site-packages\pip\req\req_set.py", line 123, in prep_for_dist
    self.req_to_install.run_egg_info()
  File "pip-tools-venv\lib\site-packages\pip\req\req_install.py", line 410, in run_egg_info
    command_desc='python setup.py egg_info')
  File "pip-tools-venv\lib\site-packages\pip\utils\__init__.py", line 702, in call_subprocess
    cwd=cwd, env=env)
  File "F:\Python2.7.8\Lib\subprocess.py", line 710, in __init__
    errread, errwrite)
  File "F:\Python2.7.8\Lib\subprocess.py", line 958, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
```

This PR fixes this error.