### PR TITLE
Add support for client ssl certificates

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -23,7 +23,7 @@ except ImportError:
 
 class PyPIRepository(BaseRepository):
     DEFAULT_INDEX_URL = 'https://pypi.python.org/simple/'
-    
+
     """
     The PyPIRepository will use the provided Finder instance to lookup
     packages.  Typically, it looks up packages on PyPI (the default implicit
@@ -32,6 +32,8 @@ class PyPIRepository(BaseRepository):
     """
     def __init__(self, pip_options):
         self.session = PipSession()
+        if pip_options.client_cert:
+            self.session.cert = pip_options.client_cert
 
         index_urls = [pip_options.index_url] + pip_options.extra_index_urls
         if pip_options.no_index:
@@ -46,7 +48,7 @@ class PyPIRepository(BaseRepository):
             process_dependency_links=pip_options.process_dependency_links,
             session=self.session,
         )
-        
+
         # Caches
         # stores project_name => InstallationCandidate mappings for all
         # versions reported by PyPI, so we only have to ask once for each

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -38,6 +38,7 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')  # noqa
 @click.option('-i', '--index-url', help="Change index URL (defaults to PyPI)", envvar='PIP_INDEX_URL')
 @click.option('--extra-index-url', multiple=True, help="Add additional index URL to search", envvar='PIP_EXTRA_INDEX_URL')  # noqa
+@click.option('--client-cert', help="Path to SSL client certificate, a single file containing the private key and the certificate in PEM format.")  # noqa
 @click.option('--trusted-host', multiple=True, envvar='PIP_TRUSTED_HOST',
               help="Mark this host as trusted, even though it does not have "
                    "valid or any HTTPS.")
@@ -45,8 +46,8 @@ class PipCommand(pip.basecommand.Command):
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")
 @click.argument('src_file', required=False, type=click.Path(exists=True), default=DEFAULT_REQUIREMENTS_FILE)
-def cli(verbose, dry_run, pre, rebuild, find_links, index_url,
-        extra_index_url, trusted_host, header, annotate, src_file):
+def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
+        client_cert, trusted_host, header, annotate, src_file):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -76,6 +77,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url,
         pip_args.extend(['-i', index_url])
     if extra_index_url:
         pip_args.extend(['--extra-index-url', extra_index_url])
+    if client_cert:
+        pip_args.extend(['--client-cert', client_cert])
     if pre:
         pip_args.extend(['--pre'])
     if trusted_host:


### PR DESCRIPTION
This adds a --client-cert option as seen in the pip command line so that you can use an alternate index which requires a client certificate for authentication.

I also got rid of two bits of empty line whitespace.