### PR TITLE
Prevent crash when using --extra-index-url

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -76,7 +76,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if index_url:
         pip_args.extend(['-i', index_url])
     if extra_index_url:
-        pip_args.extend(['--extra-index-url', extra_index_url])
+        for extra in extra_index_url:
+            pip_args.extend(['--extra-index-url', extra])
     if client_cert:
         pip_args.extend(['--client-cert', client_cert])
     if pre:


### PR DESCRIPTION
```python
$ pip freeze
...
click==5.1
pip==6.1.1
pip-tools==1.1.6
...

$ pip-compile --extra-index-url http://pypi.ytec.nl/ytec/production/
pip/index.py:302 (mkurl_pypi_url) url='https://pypi.python.org/simple', type(url)=<type 'str'>, project_url_name='babel'
pip/index.py:302 (mkurl_pypi_url) url='https://pypi.python.org/simple', type(url)=<type 'str'>, project_url_name='babel'
pip/index.py:302 (mkurl_pypi_url) url=(u'http://pypi.ytec.nl/ytec/production/',), type(url)=<type 'tuple'>, project_url_name='babel'

Traceback (most recent call last):
  File "/home/quinox/projects/ytec-translate/virtual/bin/pip-compile", line 11, in <module>
    sys.exit(cli())
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/click/core.py", line 700, in __call__
    return self.main(*args, **kwargs)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/click/core.py", line 508, in invoke
    return callback(*args, **kwargs)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/scripts/compile.py", line 117, in cli
    results = resolver.resolve()
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/resolver.py", line 78, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/resolver.py", line 156, in _resolve_one_round
    best_matches = set(self.get_best_match(ireq) for ireq in constraints)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/resolver.py", line 156, in <genexpr>
    best_matches = set(self.get_best_match(ireq) for ireq in constraints)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/resolver.py", line 203, in get_best_match
    best_match = self.repository.find_best_match(ireq, prereleases=self.prereleases)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/repositories/pypi.py", line 95, in find_best_match
    all_candidates = self.find_all_versions(ireq.name)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/piptools/repositories/pypi.py", line 84, in find_all_versions
    self._available_versions_cache[req_name] = self.finder._find_all_versions(req_name)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/pip/index.py", line 350, in _find_all_versions
    index_locations = self._get_index_urls_locations(project_name)
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/pip/index.py", line 339, in _get_index_urls_locations
    return [mkurl_pypi_url(url) for url in self.index_urls]
  File "/home/quinox/projects/ytec-translate/virtual/local/lib/python2.7/site-packages/pip/index.py", line 303, in mkurl_pypi_url
    loc = posixpath.join(url, project_url_name)
  File "/home/quinox/projects/ytec-translate/virtual/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'tuple' object has no attribute 'endswith'
```