### PR TITLE
Fix --find-links and --extra-index-urls option passing.

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -72,11 +72,13 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
 
     pip_args = []
     if find_links:
-        pip_args.extend(['-f', find_links])
+        for link in find_links:
+            pip_args.extend(['-f', link])
     if index_url:
         pip_args.extend(['-i', index_url])
     if extra_index_url:
-        pip_args.extend(['--extra-index-url', extra_index_url])
+        for extra_index in extra_index_url:
+            pip_args.extend(['--extra-index-url', extra_index])
     if client_cert:
         pip_args.extend(['--client-cert', client_cert])
     if pre:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,3 +60,32 @@ def test_command_line_overrides_pip_conf(pip_conf):
 
         # check that we have our index-url as specified in pip.conf
         assert 'Using indexes:\n  http://override.com' in out.output
+
+
+def test_find_links_option(pip_conf):
+
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['-v', '-f', './libs1', '-f', './libs2'])
+
+        # Check that find-links has been passed to pip
+        assert 'Configuration:\n  -f ./libs1\n  -f ./libs2' in out.output
+
+
+def test_extra_index_option(pip_conf):
+
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['-v',
+                                  '--extra-index-url', 'http://extraindex1.com',
+                                  '--extra-index-url', 'http://extraindex2.com'])
+        assert ('Using indexes:\n'
+                '  http://example.com\n'
+                '  http://extraindex1.com\n'
+                '  http://extraindex2.com' in out.output)


### PR DESCRIPTION
Pip options don't support multiple values passed to `.extend()`
and treats it as a single option value. This breaks when `--find-links` or
`--extra-index-urls` are passed since they are tuples because of
`multiple=True`. This commit fixes the problem and also adds some tests.