### PR TITLE
Add '-n' option as shorthand of '--dry-run' at pip-compile, pip-sync

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -35,7 +35,7 @@ class PipCommand(pip.basecommand.Command):
 
 @click.command()
 @click.option('-v', '--verbose', is_flag=True, help="Show more output")
-@click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
+@click.option('-n', '--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
 @click.option('-p', '--pre', is_flag=True, default=None, help="Allow resolving to prereleases (default is not)")
 @click.option('-r', '--rebuild', is_flag=True, help="Clear any caches upfront, rebuild from scratch")
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')  # noqa

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -23,7 +23,7 @@ DEFAULT_REQUIREMENTS_FILE = 'requirements.txt'
 
 
 @click.command()
-@click.option('--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
+@click.option('-n', '--dry-run', is_flag=True, help="Only show what would happen, don't change anything")
 @click.option('--force', is_flag=True, help="Proceed even if conflicts are found")
 @click.option('-f', '--find-links', multiple=True, help="Look for archives in this directory or on this HTML page", envvar='PIP_FIND_LINKS')  # noqa
 @click.option('--no-index', is_flag=True, help="Ignore package index (only looking at --find-links URLs instead)")


### PR DESCRIPTION
I hope use '-n' option as the short hand of '--dry-run' option.

Because these are used with a tool of major Linux.

e.g.)

* [make](http://linux.die.net/man/1/make)
* [rsync](http://linux.die.net/man/1/rsync)
* [git-add](https://www.kernel.org/pub/software/scm/git/docs/git-add.html)