### PR TITLE
Add a new --force-range switch

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -11,7 +11,8 @@ from pip.req.req_set import RequirementSet
 
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound
-from ..utils import is_pinned_requirement, lookup_table, make_install_requirement
+from ..utils import (is_pinned_requirement, lookup_table,
+                     make_install_requirement, is_range_pinned_requirement)
 from .base import BaseRepository
 
 try:
@@ -109,12 +110,18 @@ class PyPIRepository(BaseRepository):
 
     def get_dependencies(self, ireq):
         """
-        Given a pinned or an editable InstallRequirement, returns a set of
-        dependencies (also InstallRequirements, but not necessarily pinned).
-        They indicate the secondary dependencies for the given requirement.
+        Given a pinned (including range pinned) or an editable InstallRequirement,
+        returns a set of  dependencies (also InstallRequirements, but not
+        necessarily pinned). They indicate the secondary dependencies for the given
+        requirement.
         """
-        if not (ireq.editable or is_pinned_requirement(ireq)):
-            raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
+        if not (ireq.editable or
+                is_pinned_requirement(ireq)
+                or is_range_pinned_requirement(ireq)
+        ):
+            raise TypeError(
+                'Expected pinned, range pinned or editable InstallRequirement, got {}'.format(ireq)
+            )
 
         if not os.path.isdir(self._download_dir):
             os.makedirs(self._download_dir)

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -51,9 +51,11 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
+@click.option('--force-range', is_flag=True, help="Force range dependencies")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
-        client_cert, trusted_host, header, annotate, output_file, src_files):
+        client_cert, trusted_host, header, annotate, output_file, force_range,
+        src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -134,10 +136,9 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         else:
             constraints.extend(parse_requirements(
                 src_file, finder=repository.finder, session=repository.session, options=pip_options))
-
     try:
         resolver = Resolver(constraints, repository, prereleases=pre,
-                            clear_caches=rebuild)
+                            clear_caches=rebuild, force_range=force_range)
         results = resolver.resolve()
     except PipToolsError as e:
         log.error(str(e))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -73,3 +73,18 @@ def test_resolver(resolver, from_line, input, expected, prereleases):
     output = resolver(input, prereleases=prereleases).resolve()
     output = {str(line) for line in output}
     assert output == {str(line) for line in expected}
+
+def test_resolver_force_range_pinned(resolver, from_line):
+    input = [from_line('django<1.9,>=1.8')]
+
+    # Force range pinned
+    output = resolver(input, prereleases=False, force_range=True).resolve()
+    output = {str(line) for line in output}
+    expected = input
+    assert output == {str(line) for line in expected}
+
+    # Do not force range pinned
+    expected = {'django==1.8'}
+    output = resolver(input, prereleases=False).resolve()
+    output = {str(line) for line in output}
+    assert output == expected


### PR DESCRIPTION
This commit adds support for a new switch named --force--range which when specified to ``pip-compile`` will preserve the range specifications for packages instead of finding the latest package
which matches and pinning that.