### PR TITLE
Add option to omit footer from the output of pip-compile

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -46,6 +46,7 @@ class PipCommand(pip.basecommand.Command):
               help="Mark this host as trusted, even though it does not have "
                    "valid or any HTTPS.")
 @click.option('--header/--no-header', is_flag=True, default=True, help="Add header to generated file")
+@click.option('--footer/--no-footer', is_flag=True, default=True, help="Add footer to generated file")
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
@@ -53,7 +54,7 @@ class PipCommand(pip.basecommand.Command):
                     'Will be derived from input file otherwise.'))
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
-        client_cert, trusted_host, header, annotate, output_file, src_files):
+        client_cert, trusted_host, header, footer, annotate, output_file, src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -175,7 +176,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         reverse_dependencies = resolver.reverse_dependencies(results)
 
     writer = OutputWriter(src_file, output_file=output_file, dry_run=dry_run, header=header,
-                          annotate=annotate,
+                          footer=footer, annotate=annotate,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls)
     writer.write(results=results,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -10,7 +10,7 @@ from .utils import comment, format_requirement
 
 class OutputWriter(object):
     def __init__(self, src_file, dry_run, header, annotate, default_index_url,
-                 index_urls, output_file=None):
+                 index_urls, output_file=None, footer=True):
         self.src_file = src_file
         self.output_file = output_file
         self.dry_run = dry_run
@@ -18,6 +18,7 @@ class OutputWriter(object):
         self.annotate = annotate
         self.default_index_url = default_index_url
         self.index_urls = index_urls
+        self.footer = footer
 
     @property
     def dst_file(self):
@@ -66,7 +67,7 @@ class OutputWriter(object):
             line = self._format_requirement(ireq, reverse_dependencies, primary_packages)
             yield line
 
-        if unsafe_packages:
+        if unsafe_packages and self.footer:
             yield ''
             yield comment('# The following packages are commented out because they are')
             yield comment('# considered to be unsafe in a requirements file:')

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -40,3 +40,30 @@ def test_format_requirement_not_for_primary(from_line, writer):
                                        reverse_dependencies,
                                        primary_packages=['test']) ==
             'test==1.2')
+
+
+def test_footer_output(from_line, writer):
+    """Test that footer output is not suppressed by default."""
+    ireq = from_line('setuptools')
+    reverse_dependencies = {'test': ['setuptools']}
+    lines = list(writer._iter_lines([ireq],
+                                    reverse_dependencies,
+                                    primary_packages=[]))
+    # In this case, the commented requirement is expected to be in the
+    # last line of the output.
+    assert '# setuptools' in lines[-1]
+
+
+def test_footer_output_suppression(from_line, writer):
+    """Test that footer output is suppressed when it should be."""
+    # Set the writer to omit the footer in this case.
+    writer.footer = False
+    ireq = from_line('setuptools')
+    reverse_dependencies = {'test': ['setuptools']}
+    lines = list(writer._iter_lines([ireq],
+                                    reverse_dependencies,
+                                    primary_packages=[]))
+    # The commented requirement would normally be expected to be in the
+    # last line of the output. Because the footer is disabled, we assert
+    # that this line is not present.
+    assert '# setuptools' not in lines[-1]


### PR DESCRIPTION
When compiling requirements, the commented unsafe packages can create
noise. setuptools, for example, is updated frequently. The proposed
``no-footer`` option allows suppression of these comments (e.g. to
reduce noise in source control diffs or simply because a user may not
care about those packages).

The option is called ``--no-footer`` to match the existing
``--no-header`` option.