### PR TITLE
Also add the stdlib to the "already installed" list

### DIFF
--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -57,7 +57,7 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
         log.error(str(e))
         sys.exit(2)
 
-    installed_dists = pip.get_installed_distributions(skip = [])
+    installed_dists = pip.get_installed_distributions(skip=[])
     to_install, to_uninstall = sync.diff(requirements, installed_dists)
 
     pip_flags = []

--- a/piptools/scripts/sync.py
+++ b/piptools/scripts/sync.py
@@ -57,7 +57,7 @@ def cli(dry_run, force, find_links, index_url, extra_index_url, no_index, src_fi
         log.error(str(e))
         sys.exit(2)
 
-    installed_dists = pip.get_installed_distributions()
+    installed_dists = pip.get_installed_distributions(skip = [])
     to_install, to_uninstall = sync.diff(requirements, installed_dists)
 
     pip_flags = []


### PR DESCRIPTION
Without this change, on Python 3.5 `pip-sync -n` always (if argparse is in the requirements.txt) returns `Would install: argparse==1.4.0` despite argparse being already installed as part of the standard library in modern Python versions. With this change, it also considers the "stdlib pkgs" as installed, and so doesn't try to reinstall them for Python versions that have merged packages.