### PR TITLE
Remove specifiers for unsafe requirements

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -23,15 +23,17 @@ def make_install_requirement(name, version, extras):
     return InstallRequirement.from_line('{}{}=={}'.format(name, extras_string, str(version)))
 
 
-def format_requirement(ireq):
+def format_requirement(ireq, include_specifier=True):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
     """
     if ireq.editable:
         line = '-e {}'.format(ireq.link)
-    else:
+    elif include_specifier:
         line = str(ireq.req)
+    else:
+        line = ireq.req.project_name
     return line
 
 

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -81,7 +81,7 @@ class OutputWriter(object):
             yield comment('# considered to be unsafe in a requirements file:')
 
             for ireq in unsafe_packages:
-                line = self._format_requirement(ireq, reverse_dependencies, primary_packages)
+                line = self._format_requirement(ireq, reverse_dependencies, primary_packages, include_specifier=False)
                 yield comment('# ' + line)
 
     def write(self, results, reverse_dependencies, primary_packages):
@@ -96,8 +96,8 @@ class OutputWriter(object):
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))
 
-    def _format_requirement(self, ireq, reverse_dependencies, primary_packages):
-        line = format_requirement(ireq)
+    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, include_specifier=True):
+        line = format_requirement(ireq, include_specifier=include_specifier)
         if not self.annotate or ireq.name in primary_packages:
             return line
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from piptools.utils import as_tuple, format_requirement, format_specifier, flat_
 def test_format_requirement(from_line):
     ireq = from_line('test==1.2')
     assert format_requirement(ireq) == 'test==1.2'
+    assert format_requirement(ireq, include_specifier=False) == 'test'
 
 
 def test_format_requirement_editable(from_editable):


### PR DESCRIPTION
As discussed in #276, version specifiers for unsafe requirements create
noise in diffs. This change omits versions from those requirements, so
the noise is silenced.