### PR TITLE
Upgrade to container builds on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 
 # Run tox with python 3.4, but let _it_ build the envs for the various Python
@@ -20,6 +21,8 @@ env:
 
 install:
   - travis_retry pip install tox
+
+cache: pip
 
 script:
   - tox


### PR DESCRIPTION
Per the [docs](https://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F), container based builds are faster and provide caching. This should (in theory) allow for faster builds.

Builds are currently very quick (8-15 seconds per environment), but they seem to take a significant amount of time to begin (spent waiting in the build queue). I don't see any documentation on whether or not container based builds have an effect on time spent in the build queue, so this is an experiment of sorts. ``sudo`` is not currently used in the travis builds, so there are no downsides to upgrading to the new container infrastructure.

---

Edit:
Anecdotally, this was much faster ([before](https://travis-ci.org/nvie/pip-tools/builds/102690242), [after](https://travis-ci.org/nvie/pip-tools/builds/102707945)). The time per environment seems to have roughly doubled, and the reported elapsed* and total times have both gone up, but the build completed much more quickly overall (based purely on my observation).

\* Elapsed time on legacy builds seems to be only reporting the time of the final environment rather than the wall clock time. If this were "time from pull request notification until final build completed", I suspect that the container based builds would win by a significant margin.