### PR TITLE
ensure cache_dir exists

### DIFF
--- a/piptools/cache.py
+++ b/piptools/cache.py
@@ -51,6 +51,8 @@ class DependencyCache(object):
     def __init__(self, cache_dir=None):
         if cache_dir is None:
             cache_dir = CACHE_DIR
+        if not os.path.isdir(cache_dir):
+            os.makedirs(cache_dir)
         py_version = '.'.join(str(digit) for digit in sys.version_info[:2])
         cache_filename = 'depcache-py{}.json'.format(py_version)
 


### PR DESCRIPTION
Currently if you install pip-tools on a machine for the first time and use the --rebuild flag the very first time you run it, you get the following exception:

```
root@ff179494a044:/# pip-compile --rebuild requirements.in 
Traceback (most recent call last):
  File "/usr/local/bin/pip-compile", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/piptools/scripts/compile.py", line 145, in cli
    results = resolver.resolve()
  File "/usr/local/lib/python2.7/site-packages/piptools/resolver.py", line 62, in resolve
    self.dependency_cache.clear()
  File "/usr/local/lib/python2.7/site-packages/piptools/cache.py", line 107, in clear
    self.write_cache()
  File "/usr/local/lib/python2.7/site-packages/piptools/cache.py", line 102, in write_cache
    with open(self._cache_file, 'w') as f:
IOError: [Errno 2] No such file or directory: u'/root/.cache/pip-tools/depcache-py2.7.json'
```