### PR TITLE
Allow renaming on Windows

### DIFF
--- a/piptools/io.py
+++ b/piptools/io.py
@@ -44,9 +44,20 @@ else:
         return
 
 
+# rename operation fails on Windows when destination exists
+# see http://stackoverflow.com/questions/8107352/force-overwrite-in-os-rename
+if os.name == 'nt':
+    def _rename(old_path, new_path):
+        if os.path.exists(new_path):
+            os.remove(new_path)
+        os.rename(old_path, new_path)
+else:
+    _rename = os.rename
+
+
 def _atomic_rename(path, new_path, overwrite=False):
     if overwrite:
-        os.rename(path, new_path)
+        _rename(path, new_path)
     else:
         os.link(path, new_path)
         os.unlink(path)


### PR DESCRIPTION
This PR fixes a traceback on Windows when the destination requirements.txt exists (see below).

Rename operation does not work on Windows when destination exists. Unfortunately, this cannot be implemented atomically.

The proposed implementation on Windows will remove the destination file before renaming the old file.

See http://stackoverflow.com/questions/8107352/force-overwrite-in-os-rename
and https://docs.python.org/2/library/os.html#os.rename

Traceback on Windows (pip-tools-venv is a fictional path):

```
Traceback (most recent call last):
  File "F:\Python2.7.11\Lib\runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "F:\Python2.7.11\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "pip-tools-venv\Scripts\pip-compile.exe\__main__.py", line 9, in <module>
  File "pip-tools-venv\lib\site-packages\click\core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "pip-tools-venv\lib\site-packages\click\core.py", line 696, in main
    rv = self.invoke(ctx)
  File "pip-tools-venv\lib\site-packages\click\core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "pip-tools-venv\lib\site-packages\click\core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "pip-tools-venv\lib\site-packages\piptools\scripts\compile.py", line 206, in cli
    primary_packages={ireq.req.key for ireq in constraints})
  File "pip-tools-venv\lib\site-packages\piptools\writer.py", line 90, in write
    f.write(os.linesep.encode('utf-8'))
  File "pip-tools-venv\lib\site-packages\piptools\_compat\contextlib.py", line 123, in __exit__
    return _invoke_next_callback(exc_details)
  File "pip-tools-venv\lib\site-packages\piptools\_compat\contextlib.py", line 107, in _invoke_next_callback
    return cb(*exc_details)
  File "pip-tools-venv\lib\site-packages\piptools\_compat\contextlib.py", line 35, in _exit_wrapper
    return cm_exit(cm, *exc_details)
  File "pip-tools-venv\lib\site-packages\piptools\io.py", line 195, in __exit__
    overwrite=self.overwrite)
  File "pip-tools-venv\lib\site-packages\piptools\io.py", line 49, in _atomic_rename
    os.rename(path, new_path)
WindowsError: [Error 183] Cannot create a file when that file already exists
```