### PR TITLE
Added command line flag "--unsafe" to allow the pinning of

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -56,10 +56,11 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
+@click.option('--unsafe', is_flag=True, default=False, help='Allow inclusion of "unsafe" packages in requirements.txt')
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         client_cert, trusted_host, header, index, annotate, upgrade,
-        output_file, src_files):
+        output_file, unsafe, src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -196,7 +197,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if annotate:
         reverse_dependencies = resolver.reverse_dependencies(results)
 
-    writer = OutputWriter(src_file, dst_file, dry_run=dry_run,
+    writer = OutputWriter(src_file, dst_file, unsafe, dry_run=dry_run,
                           emit_header=header, emit_index=index,
                           annotate=annotate,
                           default_index_url=repository.DEFAULT_INDEX_URL,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,3 +89,15 @@ def test_extra_index_option(pip_conf):
                 '  http://example.com\n'
                 '  http://extraindex1.com\n'
                 '  http://extraindex2.com' in out.output)
+
+
+def test_unsafe_option(pip_conf):
+
+    assert os.path.exists(pip_conf)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open('requirements.in', 'w').close()
+        out = runner.invoke(cli, ['--unsafe'])
+        assert ('The following packages are included because pip-tools was invoked with --unsafe' in out.output)
+


### PR DESCRIPTION
"unsafe" dependencies; unfortunately there are some valid
instances of needing to enforce this, it seems like setuptools
in particular goes through various phases of backwards
compatibility.

I wasn't 100% certain how to run the tests ("python setup.py test"
didn't seem to do the trick) but I did add a best guess at how
to test the new option.