### PR TITLE
Add command line alias '-U' as '--upgrade'

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -51,7 +51,7 @@ class PipCommand(pip.basecommand.Command):
               help="Add index URL to generated file")
 @click.option('--annotate/--no-annotate', is_flag=True, default=True,
               help="Annotate results, indicating where dependencies come from")
-@click.option('--upgrade', is_flag=True, default=False,
+@click.option('-U', '--upgrade', is_flag=True, default=False,
               help='Try to upgrade all dependencies to their latest versions')
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '


### PR DESCRIPTION
The `-U` option is famous as alias of `--upgrade` for pip user. e.g.) `pip install -U pip`

When it is supported in pip-tools 1.6 or later, it is more convenient.