### PR TITLE
Use pip's mechanics for creating a session

### DIFF
--- a/piptools/repositories/pypi.py
+++ b/piptools/repositories/pypi.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
 import os
 from shutil import rmtree
 
-from pip.download import PipSession
 from pip.index import PackageFinder
 from pip.req.req_set import RequirementSet
 
@@ -30,10 +29,8 @@ class PyPIRepository(BaseRepository):
     config), but any other PyPI mirror can be used if index_urls is
     changed/configured on the Finder.
     """
-    def __init__(self, pip_options):
-        self.session = PipSession()
-        if pip_options.client_cert:
-            self.session.cert = pip_options.client_cert
+    def __init__(self, pip_options, session):
+        self.session = session
 
         index_urls = [pip_options.index_url] + pip_options.extra_index_urls
         if pip_options.no_index:

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -89,13 +89,13 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     # Use pip's parser for pip.conf management and defaults.
     # General options (find_links, index_url, extra_index_url, trusted_host,
     # and pre) are defered to pip.
-    pip_options = PipCommand()
+    pip_command = PipCommand()
     index_opts = pip.cmdoptions.make_option_group(
         pip.cmdoptions.index_group,
-        pip_options.parser,
+        pip_command.parser,
     )
-    pip_options.parser.insert_option_group(0, index_opts)
-    pip_options.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
+    pip_command.parser.insert_option_group(0, index_opts)
+    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
 
     pip_args = []
     if find_links:
@@ -114,9 +114,10 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         for host in trusted_host:
             pip_args.extend(['--trusted-host', host])
 
-    pip_options, _ = pip_options.parse_args(pip_args)
+    pip_options, _ = pip_command.parse_args(pip_args)
 
-    repository = PyPIRepository(pip_options)
+    session = pip_command._build_session(pip_options)
+    repository = PyPIRepository(pip_options, session)
 
     # Proxy with a LocalRequirementsRepository if --upgrade is not specified
     # (= default invocation)


### PR DESCRIPTION
Instead of making an empty PipSession object, use pip's implementation.

This allows for using pip config for client-cert, trusted-hosts etc.