### PR TITLE
Update README.md to match new pip-compile behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ werkzeug==0.10.4          # via flask
 
 And it will produce your `requirements.txt`, with all the Flask dependencies
 (and all underlying dependencies) pinned.  Put this file under version control
-as well. To update your packages to the latest versions available on PyPI
+as well.  To update your packages to the latest versions available on PyPI
 , run `pip-compile --upgrade`.
 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ werkzeug==0.10.4          # via flask
 
 And it will produce your `requirements.txt`, with all the Flask dependencies
 (and all underlying dependencies) pinned.  Put this file under version control
-as well and periodically re-run `pip-compile` to update the packages.
+as well. To update your packages to the latest versions available on PyPI
+, run `pip-compile --upgrade`.
 
 
 Example usage for `pip-sync`


### PR DESCRIPTION
Before I read the changelog, I was a little confused about why `pip-compile` would not update my packages. This should clarify the behavior for future users.