### PR TITLE
Add missing word in example comment

### DIFF
--- a/examples/sentry.in
+++ b/examples/sentry.in
@@ -1,2 +1,2 @@
-# Sentry has a very dependency tree
+# Sentry has a very large dependency tree
 sentry


### PR DESCRIPTION
I'm assuming "large" was the intended word.