### PR TITLE
fix MSVCRT Python's file renaming bug refs fix-windows-overwrite

### DIFF
--- a/piptools/io.py
+++ b/piptools/io.py
@@ -8,6 +8,10 @@ import errno
 import os
 import stat
 
+if os.name == 'nt':
+    from ctypes import windll
+
+
 RW_PERMS = 438
 
 _TEXT_OPENFLAGS = os.O_RDWR | os.O_CREAT | os.O_EXCL
@@ -46,7 +50,12 @@ else:
 
 def _atomic_rename(path, new_path, overwrite=False):
     if overwrite:
-        os.rename(path, new_path)
+        if os.name == 'nt':
+            # atomic renaming on python build on msvc
+            # ReplaceFile enalbe you to file renaming atomically.
+            windll.kernel32.ReplaceFile(path, new_path)
+        else:
+            os.rename(path, new_path)
     else:
         os.link(path, new_path)
         os.unlink(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,10 +15,6 @@ def test__atomic_rename_can_overwrite():
 
         ppt_io._atomic_rename(path, new_path, overwrite=True)
     finally:
-        try:
+        if os.path.isfile(path):
             os.remove(path)
-        except:
-            # If move file0 to file1,
-            # there is no file on file0's path.
-            pass
         os.remove(new_path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+
+from piptools import io as ppt_io
+
+
+def test__atomic_rename_can_overwrite():
+    try:
+        fd, path = tempfile.mkstemp()
+        new_fd, new_path = tempfile.mkstemp()
+
+        # close for to remove tmp files
+        for _fd in [fd, new_fd]:
+            os.fdopen(_fd).close()
+
+        ppt_io._atomic_rename(path, new_path, overwrite=True)
+    finally:
+        try:
+            os.remove(path)
+        except:
+            # If move file0 to file1,
+            # there is no file on file0's path.
+            pass
+        os.remove(new_path)


### PR DESCRIPTION
Hello.

I'm using Windows MSVCRS's Python.

When original requirements.txt exists and pip-compile on that, I got an error.

I fix it, and please merge it.

Best regards.

* Traceback

  ```
  Traceback (most recent call last):
    File "C:\Python\3.5.1.amd64\lib\runpy.py", line 170, in _run_module_as_main
      "__main__", mod_spec)
    File "C:\Python\3.5.1.amd64\lib\runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "D:\tomo\Documents\misc\venvs\pyvenv351\Scripts\pip-compile.exe\__main__.py", line 9, in <module>
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\click\core.py", line 716, in __call__
      return self.main(*args, **kwargs)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\click\core.py", line 696, in main
      rv = self.invoke(ctx)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\click\core.py", line 889, in invoke
      return ctx.invoke(self.callback, **ctx.params)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\click\core.py", line 534, in invoke
      return callback(*args, **kwargs)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\piptools\scripts\compile.py", line 206, in cli
      primary_packages={ireq.req.key for ireq in constraints})
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\piptools\writer.py", line 99, in write
      f.write(os.linesep.encode('utf-8'))
    File "C:\Python\3.5.1.amd64\lib\contextlib.py", line 357, in __exit__
      raise exc_details[1]
    File "C:\Python\3.5.1.amd64\lib\contextlib.py", line 342, in __exit__
      if cb(*exc_details):
    File "C:\Python\3.5.1.amd64\lib\contextlib.py", line 258, in _exit_wrapper
      return cm_exit(cm, *exc_details)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\piptools\io.py", line 195, in __exit__
      overwrite=self.overwrite)
    File "d:\tomo\documents\misc\venvs\pyvenv351\lib\site-packages\piptools\io.py", line 49, in _atomic_rename
      os.rename(path, new_path)
  FileExistsError: [WinError 183] 既に存在するファイルを作成することはできません。: 'requirementx.txt.part' -> 'D:\\tomo\\Documents\\requirementx.txt'
  ```
