### PR TITLE
Fix reading from stdin with Python 3

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -146,7 +146,11 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
             # piping from stdin, we need to briefly save the input from stdin
             # to a temporary file and have pip read that.
             with tempfile.NamedTemporaryFile() as tmpfile:
-                tmpfile.write(sys.stdin.read())
+                if sys.stdin.buffer:  # Python 3.
+                    stdin = sys.stdin.buffer.read()
+                else:
+                    stdin = sys.stdin.read()
+                tmpfile.write(stdin)
                 tmpfile.flush()
                 constraints.extend(parse_requirements(
                     tmpfile.name, finder=repository.finder, session=repository.session, options=pip_options))


### PR DESCRIPTION
This fixes the following error:

> TypeError: a bytes-like object is required, not 'str'

Source: http://stackoverflow.com/a/32282458/15690

TEST CASE:
1. `cat test.in | pip-compile --output-file test.txt -`