### PR TITLE
Add support for pip 8.1.2

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -2,7 +2,23 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from piptools.utils import key_from_req
 from .base import BaseRepository
+
+
+def ireq_satisfied_by_existing_pin(ireq, existing_pin):
+    """
+    Return True if the given InstallationRequirement is satisfied by the
+    previously encountered version pin.
+    """
+    if hasattr(existing_pin.req, 'specs'):
+        # pip < 8.1.2
+        version = existing_pin.req.specs[0][1]
+        return version in ireq.req
+    else:
+        # pip >= 8.1.2
+        version = next(iter(existing_pin.req.specifier)).version
+        return version in ireq.req.specifier
 
 
 class LocalRequirementsRepository(BaseRepository):
@@ -38,8 +54,9 @@ class LocalRequirementsRepository(BaseRepository):
         self.repository.freshen_build_caches()
 
     def find_best_match(self, ireq, prereleases=None):
-        existing_pin = self.existing_pins.get(ireq.req.project_name.lower())
-        if existing_pin and existing_pin.req.specs[0][1] in ireq.req:
+        key = key_from_req(ireq.req)
+        existing_pin = self.existing_pins.get(key)
+        if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             return existing_pin
         else:
             return self.repository.find_best_match(ireq, prereleases)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,7 @@ def test_extra_index_option(pip_conf):
                 '  http://extraindex1.com\n'
                 '  http://extraindex2.com' in out.output)
 
+
 def test_trusted_host(pip_conf):
 
     assert os.path.exists(pip_conf)

--- a/tests/test_minimal_upgrade.py
+++ b/tests/test_minimal_upgrade.py
@@ -1,5 +1,6 @@
 import pytest
 from piptools.repositories import LocalRequirementsRepository
+from piptools.utils import name_from_req
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,7 @@ def test_no_upgrades(base_resolver, repository, from_line, input, pins, expected
     existing_pins = dict()
     for line in pins:
         ireq = from_line(line)
-        existing_pins[ireq.req.project_name] = ireq
+        existing_pins[name_from_req(ireq.req)] = ireq
     local_repository = LocalRequirementsRepository(existing_pins, repository)
     output = base_resolver(input, prereleases=False, repository=local_repository).resolve()
     output = {str(line) for line in output}


### PR DESCRIPTION
Proposed fix for https://github.com/nvie/pip-tools/issues/358 . pip 8.1.2 switched from [pkg_resources](http://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-objects) to [packaging](https://packaging.pypa.io/en/latest/requirements/) for its internal representation of requirements.  This PR adds a few utility functions and a wrapper class to handle the differences that pip-tools cares about so it can work with pip 8.1.2 in addition to all the previously supported versions.

I looked into switching over from pip to `packaging` directly, but it lacks some of the required features (like [parsing editable requirements](https://github.com/pypa/packaging/issues/64)) and they've been deemed out of scope for that package.  In the long term, there will probably be a new package specifically for parsing requirements files (which utilizes `packaging` where it can, and could have a vendored version included in pip for use there).

I also fixed a minor whitespace issue in `tests/test_cli.py` that was causing a flake8 failure.