### PR TITLE
Add option to pin packages considered unsafe in pip-compile

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -53,12 +53,12 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
-@click.option('-u', '--pin-unsafe', is_flag=True, default=False,
+@click.option('--allow-unsafe', is_flag=True, default=False,
               help="Pin packages considered unsafe: pip, setuptools & distribute")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         client_cert, trusted_host, header, index, annotate, upgrade,
-        output_file, pin_unsafe, src_files):
+        output_file, allow_unsafe, src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -203,7 +203,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           index_urls=repository.finder.index_urls,
                           trusted_hosts=pip_options.trusted_hosts,
                           format_control=repository.finder.format_control,
-                          pin_unsafe=pin_unsafe)
+                          allow_unsafe=allow_unsafe)
     writer.write(results=results,
                  reverse_dependencies=reverse_dependencies,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints})

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -53,10 +53,12 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
+@click.option('-u', '--unsafe', is_flag=True, default=False,
+              help="Pin packages considered unsafe: pip, setuptools & distribute")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         client_cert, trusted_host, header, index, annotate, upgrade,
-        output_file, src_files):
+        output_file, pin_unsafe, src_files):
     """Compiles requirements.txt from requirements.in specs."""
     log.verbose = verbose
 
@@ -200,7 +202,8 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                           default_index_url=repository.DEFAULT_INDEX_URL,
                           index_urls=repository.finder.index_urls,
                           trusted_hosts=pip_options.trusted_hosts,
-                          format_control=repository.finder.format_control)
+                          format_control=repository.finder.format_control,
+                          pin_unsafe=pin_unsafe)
     writer.write(results=results,
                  reverse_dependencies=reverse_dependencies,
                  primary_packages={key_from_req(ireq.req) for ireq in constraints})

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -53,7 +53,7 @@ class PipCommand(pip.basecommand.Command):
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
-@click.option('-u', '--unsafe', is_flag=True, default=False,
+@click.option('-u', '--pin-unsafe', is_flag=True, default=False,
               help="Pin packages considered unsafe: pip, setuptools & distribute")
 @click.argument('src_files', nargs=-1, type=click.Path(exists=True, allow_dash=True))
 def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -93,7 +93,9 @@ class OutputWriter(object):
             yield comment('# The following packages are considered to be unsafe in a requirements file:')
 
             for ireq in unsafe_packages:
-                line = self._format_requirement(ireq, reverse_dependencies, primary_packages, include_specifier=self.pin_unsafe)
+                line = self._format_requirement(
+                    ireq, reverse_dependencies, primary_packages,
+                    include_specifier=self.pin_unsafe)
                 if self.pin_unsafe:
                     yield line
                 else:

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -11,7 +11,7 @@ from .utils import comment, format_requirement
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
                  annotate, default_index_url, index_urls, trusted_hosts,
-                 format_control, pin_unsafe=False):
+                 format_control, allow_unsafe=False):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
@@ -22,7 +22,7 @@ class OutputWriter(object):
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
         self.format_control = format_control
-        self.pin_unsafe = pin_unsafe
+        self.allow_unsafe = allow_unsafe
 
     def _sort_key(self, ireq):
         return (not ireq.editable, str(ireq.req).lower())
@@ -95,8 +95,8 @@ class OutputWriter(object):
             for ireq in unsafe_packages:
                 line = self._format_requirement(
                     ireq, reverse_dependencies, primary_packages,
-                    include_specifier=self.pin_unsafe)
-                if self.pin_unsafe:
+                    include_specifier=self.allow_unsafe)
+                if self.allow_unsafe:
                     yield line
                 else:
                     yield comment('# ' + line)

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -9,8 +9,9 @@ from .utils import comment, format_requirement
 
 
 class OutputWriter(object):
-    def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index, annotate,
-                 default_index_url, index_urls, trusted_hosts, format_control, pin_unsafe=False):
+    def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
+                 annotate, default_index_url, index_urls, trusted_hosts,
+                 format_control, pin_unsafe=False):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -10,7 +10,7 @@ from .utils import comment, format_requirement
 
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index, annotate,
-                 default_index_url, index_urls, trusted_hosts, format_control, pin_unsafe):
+                 default_index_url, index_urls, trusted_hosts, format_control, pin_unsafe=False):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run


### PR DESCRIPTION
Due to some specifics I had to include some version of `pip` in dependencies in several projects.
I am not sure it is needed for everyone, so I added a flag to have an option to enable that.