### PR TITLE
Generate pip 8 style hashes with --generate-hashes

### DIFF
--- a/piptools/repositories/base.py
+++ b/piptools/repositories/base.py
@@ -30,3 +30,11 @@ class BaseRepository(object):
         dependencies (also InstallRequirements, but not necessarily pinned).
         They indicate the secondary dependencies for the given requirement.
         """
+
+    @abstractmethod
+    def get_hashes(self, ireq):
+        """
+        Given a pinned InstallRequire, returns a set of hashes that represent
+        all of the files for a given requirement. It is not acceptable for an
+        editable or unpinned requirement to be passed to this function.
+        """

--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -63,3 +63,6 @@ class LocalRequirementsRepository(BaseRepository):
 
     def get_dependencies(self, ireq):
         return self.repository.get_dependencies(ireq)
+
+    def get_hashes(self, ireq):
+        return self.repository.get_hashes(ireq)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -73,6 +73,12 @@ class Resolver(object):
         return set(self._group_constraints(chain(self.our_constraints,
                                                  self.their_constraints)))
 
+    def resolve_hashes(self, ireqs):
+        """
+        Finds acceptable hashes for all of the given InstallRequirements.
+        """
+        return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
+
     def resolve(self, max_rounds=10):
         """
         Finds concrete package versions for all the given InstallRequirements

--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -10,14 +10,15 @@ from .utils import comment, format_requirement
 
 class OutputWriter(object):
     def __init__(self, src_files, dst_file, dry_run, emit_header, emit_index,
-                 annotate, default_index_url, index_urls, trusted_hosts,
-                 format_control, allow_unsafe=False):
+                 annotate, generate_hashes, default_index_url, index_urls,
+                 trusted_hosts, format_control, allow_unsafe=False):
         self.src_files = src_files
         self.dst_file = dst_file
         self.dry_run = dry_run
         self.emit_header = emit_header
         self.emit_index = emit_index
         self.annotate = annotate
+        self.generate_hashes = generate_hashes
         self.default_index_url = default_index_url
         self.index_urls = index_urls
         self.trusted_hosts = trusted_hosts
@@ -38,6 +39,8 @@ class OutputWriter(object):
                 params += ['--no-index']
             if not self.annotate:
                 params += ['--no-annotate']
+            if self.generate_hashes:
+                params += ["--generate-hashes"]
             params += ['--output-file', self.dst_file]
             params += self.src_files
             yield comment('#    pip-compile {}'.format(' '.join(params)))
@@ -71,7 +74,7 @@ class OutputWriter(object):
         if emitted:
             yield ''
 
-    def _iter_lines(self, results, reverse_dependencies, primary_packages):
+    def _iter_lines(self, results, reverse_dependencies, primary_packages, hashes):
         for line in self.write_header():
             yield line
         for line in self.write_flags():
@@ -85,7 +88,7 @@ class OutputWriter(object):
         unsafe_packages = sorted(unsafe_packages, key=self._sort_key)
 
         for ireq in packages:
-            line = self._format_requirement(ireq, reverse_dependencies, primary_packages)
+            line = self._format_requirement(ireq, reverse_dependencies, primary_packages, hashes)
             yield line
 
         if unsafe_packages:
@@ -95,26 +98,33 @@ class OutputWriter(object):
             for ireq in unsafe_packages:
                 line = self._format_requirement(
                     ireq, reverse_dependencies, primary_packages,
+                    hashes if self.allow_unsafe else None,
                     include_specifier=self.allow_unsafe)
                 if self.allow_unsafe:
                     yield line
                 else:
                     yield comment('# ' + line)
 
-    def write(self, results, reverse_dependencies, primary_packages):
+    def write(self, results, reverse_dependencies, primary_packages, hashes):
         with ExitStack() as stack:
             f = None
             if not self.dry_run:
                 f = stack.enter_context(AtomicSaver(self.dst_file))
 
-            for line in self._iter_lines(results, reverse_dependencies, primary_packages):
+            for line in self._iter_lines(results, reverse_dependencies, primary_packages, hashes):
                 log.info(line)
                 if f:
                     f.write(unstyle(line).encode('utf-8'))
                     f.write(os.linesep.encode('utf-8'))
 
-    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, include_specifier=True):
+    def _format_requirement(self, ireq, reverse_dependencies, primary_packages, hashes, include_specifier=True):
         line = format_requirement(ireq, include_specifier=include_specifier)
+
+        ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
+        if ireq_hashes:
+            for hash_ in sorted(ireq_hashes):
+                line += " \\\n    --hash={}".format(hash_)
+
         if not self.annotate or ireq.name in primary_packages:
             return line
 


### PR DESCRIPTION
This adds a flag, `--generate-hashes` to `pip-compile` which will cause the output requirements.txt file to contain all of the hashes that are valid for a particular pinned version. This allows people to "compile" their requirements even further, not only locking in the specific versions, but also the specific files that are allowed to resolve their dependencies.

This does not ensure that the files are not malicious, but it does eliminate the ability for, once a file has been "compiled", PyPI to attack the person installing from this requirements file.

As an example, given a `requirements.in` like:

```
Pyramid
```

You'll get an output like:

```
$ pip-compile requirements.in
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --output-file requirements.txt requirements.in
#
PasteDeploy==1.5.2        # via pyramid
Pyramid==1.7
repoze.lru==0.6           # via pyramid
translationstring==1.3    # via pyramid
venusian==1.0             # via pyramid
WebOb==1.6.1              # via pyramid
zope.deprecation==4.1.2   # via pyramid
zope.interface==4.2.0     # via pyramid

# The following packages are considered to be unsafe in a requirements file:
# setuptools                # via pyramid, zope.deprecation, zope.interface
```

```
$ pip-compile --generate-hashes requirements.in
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --generate-hashes --output-file requirements.txt requirements.in
#
PasteDeploy==1.5.2 \
    --hash=sha256:39973e73f391335fac8bc8a8a95f7d34a9f42e2775600ce2dc518d93b37ef943 \
    --hash=sha256:d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb  # via pyramid
Pyramid==1.7 \
    --hash=sha256:16435a685503d0b92ff2d99656cf4398cb8bc5927ef904f6e665a6ea3813c850 \
    --hash=sha256:26f6b126f76a5ade38a5c1c2004ebd5ed52a30a014b329001e96627c36533898
repoze.lru==0.6 \
    --hash=sha256:0f7a323bf716d3cb6cb3910cd4fccbee0b3d3793322738566ecce163b01bbd31  # via pyramid
translationstring==1.3 \
    --hash=sha256:4ee44cfa58c52ade8910ea0ebc3d2d84bdcad9fa0422405b1801ec9b9a65b72d \
    --hash=sha256:e26c7bf383413234ed442e0980a2ebe192b95e3745288a8fd2805156d27515b4  # via pyramid
venusian==1.0 \
    --hash=sha256:1720cff2ca9c369c840c1d685a7c7a21da1afa687bfe62edd93cae4bf429ca5a  # via pyramid
WebOb==1.6.1 \
    --hash=sha256:509ce06406bd9c63fc6fba4ea5e96d17f6080f126d6303d6ab583b5f20c3eced \
    --hash=sha256:e804c583bd0fb947bd7c03d296942b38b985cf1da4fd82bf879994d29edb21fe  # via pyramid
zope.deprecation==4.1.2 \
    --hash=sha256:fed622b51ffc600c13cc5a5b6916b8514c115f34f7ea2730409f30c061eb0b78  # via pyramid
zope.interface==4.2.0 \
    --hash=sha256:36762743940a075283e1fb22a2ec9e8231871dace2aa00599511ddc4edf0f8f9 \
    --hash=sha256:e75c5ffbe6883db1d8d74f1634ea8e8edc7c0dee78d56ffc3c4de25fcfe28eac  # via pyramid

# The following packages are considered to be unsafe in a requirements file:
# setuptools                # via pyramid, zope.deprecation, zope.interface
```

```
$ pip-compile --generate-hashes --allow-unsafe requirements.in
#
# This file is autogenerated by pip-compile
# To update, run:
#
#    pip-compile --generate-hashes --output-file requirements.txt requirements.in
#
PasteDeploy==1.5.2 \
    --hash=sha256:39973e73f391335fac8bc8a8a95f7d34a9f42e2775600ce2dc518d93b37ef943 \
    --hash=sha256:d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb  # via pyramid
Pyramid==1.7 \
    --hash=sha256:16435a685503d0b92ff2d99656cf4398cb8bc5927ef904f6e665a6ea3813c850 \
    --hash=sha256:26f6b126f76a5ade38a5c1c2004ebd5ed52a30a014b329001e96627c36533898
repoze.lru==0.6 \
    --hash=sha256:0f7a323bf716d3cb6cb3910cd4fccbee0b3d3793322738566ecce163b01bbd31  # via pyramid
translationstring==1.3 \
    --hash=sha256:4ee44cfa58c52ade8910ea0ebc3d2d84bdcad9fa0422405b1801ec9b9a65b72d \
    --hash=sha256:e26c7bf383413234ed442e0980a2ebe192b95e3745288a8fd2805156d27515b4  # via pyramid
venusian==1.0 \
    --hash=sha256:1720cff2ca9c369c840c1d685a7c7a21da1afa687bfe62edd93cae4bf429ca5a  # via pyramid
WebOb==1.6.1 \
    --hash=sha256:509ce06406bd9c63fc6fba4ea5e96d17f6080f126d6303d6ab583b5f20c3eced \
    --hash=sha256:e804c583bd0fb947bd7c03d296942b38b985cf1da4fd82bf879994d29edb21fe  # via pyramid
zope.deprecation==4.1.2 \
    --hash=sha256:fed622b51ffc600c13cc5a5b6916b8514c115f34f7ea2730409f30c061eb0b78  # via pyramid
zope.interface==4.2.0 \
    --hash=sha256:36762743940a075283e1fb22a2ec9e8231871dace2aa00599511ddc4edf0f8f9 \
    --hash=sha256:e75c5ffbe6883db1d8d74f1634ea8e8edc7c0dee78d56ffc3c4de25fcfe28eac  # via pyramid

# The following packages are considered to be unsafe in a requirements file:
setuptools==25.1.6 \
    --hash=sha256:281e7d21a3e23d0b7d19992ed52fda5b16a9837654de824ce22ae6b80f0e8f96 \
    --hash=sha256:6a3f43a697459f9cca41e177cd3168dc8f949242498405d522e56497dddf0179 \
    --hash=sha256:e61bfdbde3bfa53a7cff3a0eed10cc276338ce226a9eab6837db7f632403de7f  # via pyramid, zope.deprecation, zope.interface
```

Refs #303
