### PR TITLE
Use back up versions in case pip-compile fails to do dependency resolution

### DIFF
--- a/piptools/repositories/local.py
+++ b/piptools/repositories/local.py
@@ -53,13 +53,13 @@ class LocalRequirementsRepository(BaseRepository):
     def freshen_build_caches(self):
         self.repository.freshen_build_caches()
 
-    def find_best_match(self, ireq, prereleases=None):
+    def find_best_match(self, ireq, prereleases=None, backup_versions=None):
         key = key_from_req(ireq.req)
         existing_pin = self.existing_pins.get(key)
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             return existing_pin
         else:
-            return self.repository.find_best_match(ireq, prereleases)
+            return self.repository.find_best_match(ireq, prereleases, backup_versions=backup_versions)
 
     def get_dependencies(self, ireq):
         return self.repository.get_dependencies(ireq)

--- a/piptools/resolver.py
+++ b/piptools/resolver.py
@@ -53,7 +53,8 @@ class RequirementSummary(object):
 
 
 class Resolver(object):
-    def __init__(self, constraints, repository, cache=None, prereleases=False, clear_caches=False):
+    def __init__(self, constraints, repository, cache=None, backup_versions=None,
+                 prereleases=False, clear_caches=False):
         """
         This class resolves a given set of constraints (a collection of
         InstallRequirement objects) by consulting the given Repository and the
@@ -67,6 +68,7 @@ class Resolver(object):
         self.dependency_cache = cache
         self.prereleases = prereleases
         self.clear_caches = clear_caches
+        self.backup_versions = backup_versions
 
     @property
     def constraints(self):
@@ -223,7 +225,11 @@ class Resolver(object):
             # hitting the index server
             best_match = ireq
         else:
-            best_match = self.repository.find_best_match(ireq, prereleases=self.prereleases)
+            best_match = self.repository.find_best_match(
+                ireq,
+                prereleases=self.prereleases,
+                backup_versions=self.backup_versions
+            )
 
         # Format the best match
         log.debug('  found candidate {} (constraint was {})'.format(format_requirement(best_match),
@@ -259,6 +265,7 @@ class Resolver(object):
         dependency_strings = self.dependency_cache[ireq]
         log.debug('  {:25} requires {}'.format(format_requirement(ireq),
                                                ', '.join(sorted(dependency_strings, key=lambda s: s.lower())) or '-'))
+
         for dependency_string in dependency_strings:
             yield InstallRequirement.from_line(dependency_string)
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'click>=6',
         'first',
         'six',
+        'simplejson'
     ],
     zip_safe=False,
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ class FakeRepository(BaseRepository):
         with open('tests/fixtures/fake-editables.json', 'r') as f:
             self.editables = json.load(f)
 
-    def find_best_match(self, ireq, prereleases=False):
+    def find_best_match(self, ireq, prereleases=False, backup_versions=None):
         if ireq.editable:
             return ireq
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pip811: pip<8.1.2
     coverage
     pytest
+    simplejson
 commands =
     python -c 'import pip; print("Using pip %s" % pip.__version__)'
     python -m coverage run --source piptools -m pytest --strict {posargs:tests/}


### PR DESCRIPTION
This is a fix for the following issue https://github.com/nvie/pip-tools/issues/366 where two level dependencies in turn have a single dependency that are pinned to different versions respectively. In such a case the following error happens.

```bash
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Finding the best candidates:
  found candidate alabaster==0.7.9 (constraint was >=0.7,<0.8)
  found candidate argh==0.26.2 (constraint was >=0.24.1)
  found candidate argparse==1.4.0 (constraint was <any>)
  found candidate asq==1.0 (constraint was ==1.0)
  found candidate astroid==1.0.1 (constraint was ==1.0.1)
  found candidate autopep8==1.1.1 (constraint was ==1.1.1)
  found candidate babel==2.3.4 (constraint was >=1.3,!=2.0)
  found candidate backports.ssl-match-hostname==3.5.0.1 (constraint was <any>)
  found candidate beautifulsoup4==4.4.1 (constraint was ==4.4.1)
  found candidate billiard==3.3.0.23 (constraint was >=3.3.0.21,<3.4)
  found candidate bleach==1.4.2 (constraint was ==1.4.2)
  found candidate blessings==1.6 (constraint was ==1.6)
  found candidate celery==3.1.19 (constraint was ==3.1.19)
  found candidate celery-redis-sentinel==0.3 (constraint was ==0.3)
  found candidate certifi==2016.8.31 (constraint was <any>)
  found candidate cffi==1.7.0 (constraint was ==1.7.0)
  found candidate click==6.3 (constraint was ==6.3)
  found candidate contextlib2==0.5.4 (constraint was <any>)
Could not find a version that matches coverage==3.6,==3.7.1,>=3.4
Tried: 2.8, 2.77, 2.78, 2.80, 2.85, 3.0b3, 3.0, 3.0.1, 3.1b1, 3.1, 3.2b1, 3.2b2, 3.2b3, 3.2b4, 3.2, 3.3, 3.3.1, 3.4b1, 3.4b2, 3.4, 3.5b1, 3.5, 3.5.1b1, 3.5.1,
 3.5.2b1, 3.5.2, 3.5.3, 3.6b1, 3.6b2, 3.6b3, 3.6, 3.7, 3.7.1, 4.0a1, 4.0a2, 4.0a3, 4.0a4, 4.0a5, 4.0a5, 4.0a5, 4.0a6, 4.0a6, 4.0a6, 4.0b1, 4.0b1, 4.0b2, 4.0b2
, 4.0b3, 4.0b3, 4.0, 4.0, 4.0.1, 4.0.1, 4.0.2, 4.0.2, 4.0.3, 4.0.3, 4.1b1, 4.1b1, 4.1b2, 4.1b2, 4.1b3, 4.1b3, 4.1, 4.1, 4.2b1, 4.2b1, 4.2, 4.2
```

In the above example I might only care about `coverage==3.6` and not care about other versions. But right now in the above scenario `pip-compile` just quits on us.

In such a case, this pr gives the option to provide an optional parameter to a file containing json data that has backup versions of your required dependencies, in case pip-compile faces the above error.

For e.g in this case a `backup_versions.txt` could simply be a file containing a json below.
```
{
   "coverage": "3.6",
   "click": "6.6"   
}
# Add other backup versions similarly.
```

Then you would just provide the path of the backup file when doing pip-compile

`pip-compile -vv requirements.in --backup-versions backup_versions.txt`