### PR TITLE
Added mode='wt' to tempfile creation.

### DIFF
--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -148,7 +148,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
             # pip requires filenames and not files. Since we want to support
             # piping from stdin, we need to briefly save the input from stdin
             # to a temporary file and have pip read that.
-            with tempfile.NamedTemporaryFile() as tmpfile:
+            with tempfile.NamedTemporaryFile(mode='wt') as tmpfile:
                 tmpfile.write(sys.stdin.read())
                 tmpfile.flush()
                 constraints.extend(parse_requirements(


### PR DESCRIPTION
This allows to write text into the file directly (as stdin.read()
returns a text type and by default tmpfile.write expects bytes).