### PR TITLE
Support specifying which packages and versions to update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,17 @@ werkzeug==0.10.4          # via flask
 
 And it will produce your `requirements.txt`, with all the Flask dependencies
 (and all underlying dependencies) pinned.  Put this file under version control
-as well and periodically re-run `pip-compile --upgrade` to update the packages.
+as well.
 
+To update all packages, periodically re-run `pip-compile --upgrade`.
+
+To update a specific package to the latest or a specific version use the `--upgrade-package` or `-P` flag:
+
+```console
+$ pip-compile --upgrade-package flask  # only update the flask package
+$ pip-compile --upgrade-package flask --upgrade-package requests  # update both the flask and requests packages
+$ pip-compile -P flask -P requests==2.0.0  # update the flask package to the latest, and requests to v2.0.0
+```
 
 Example usage for `pip-sync`
 ============================

--- a/piptools/scripts/compile.py
+++ b/piptools/scripts/compile.py
@@ -50,7 +50,8 @@ class PipCommand(pip.basecommand.Command):
               help="Annotate results, indicating where dependencies come from")
 @click.option('-U', '--upgrade', is_flag=True, default=False,
               help='Try to upgrade all dependencies to their latest versions')
-@click.option('-P', '--upgrade-package', nargs=1, multiple=True, help="Specify particular packages to upgrade.")
+@click.option('-P', '--upgrade-package', nargs=1, multiple=True,
+              help="Specify particular packages to upgrade.")
 @click.option('-o', '--output-file', nargs=1, type=str, default=None,
               help=('Output file name. Required if more than one input file is given. '
                     'Will be derived from input file otherwise.'))
@@ -72,20 +73,24 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     if len(src_files) == 1 and src_files[0] == '-':
         if not output_file:
             raise click.BadParameter('--output-file is required if input is from stdin')
-        if upgrade_package:
-            raise click.BadParameter('upgrade_package does not support input from stdin.')
 
     if len(src_files) > 1 and not output_file:
         raise click.BadParameter('--output-file is required if two or more input files are given.')
-
-    if upgrade and upgrade_package:
-        raise click.BadParameter('Only one of --upgrade or --upgrade_package can be provided as an argument.')
 
     if output_file:
         dst_file = output_file
     else:
         base_name, _, _ = src_files[0].rpartition('.')
         dst_file = base_name + '.txt'
+
+    if upgrade and upgrade_package:
+        raise click.BadParameter('Only one of --upgrade or --upgrade-package can be provided as an argument.')
+
+    # Process the arguments to upgrade-package into name and version pairs.
+    upgrade_package_reqs = [
+        package.split('==') if '==' in package else (package, None)
+        for package in upgrade_package
+    ]
 
     ###
     # Setup
@@ -122,22 +127,24 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     pip_options, _ = pip_command.parse_args(pip_args)
 
     session = pip_command._build_session(pip_options)
+
     repository = live_repository = PyPIRepository(pip_options, session)
+    local_repository = None
+    use_local_repo = not upgrade and os.path.exists(dst_file)
 
     # Proxy with a LocalRequirementsRepository if --upgrade is not specified
     # (= default invocation)
-    if not upgrade and os.path.exists(dst_file):
+    if use_local_repo:
         existing_pins = dict()
         ireqs = parse_requirements(dst_file, finder=repository.finder, session=repository.session, options=pip_options)
         for ireq in ireqs:
             if is_pinned_requirement(ireq):
                 existing_pins[name_from_req(ireq.req).lower()] = ireq
 
-        if upgrade_package:
-            for package in upgrade_package:
-                if package not in existing_pins:
-                    log.error("Asked to upgrade %s but it's not already pinned. Quitting..." % package)
-                    sys.exit(2)
+        for package, _ in upgrade_package_reqs:
+            if package not in existing_pins:
+                log.error("Asked to upgrade %s but it's not present in existing requirements. Quitting..." % package)
+                sys.exit(2)
 
         repository = local_repository = LocalRequirementsRepository(existing_pins, repository)
 
@@ -156,7 +163,7 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
     ###
 
     constraints = []
-    repository = live_repository if upgrade else local_repository
+    repository = local_repository if use_local_repo else live_repository
     for src_file in src_files:
         if src_file == '-':
             # pip requires filenames and not files. Since we want to support
@@ -177,8 +184,10 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
         upgraded_requirements = {}
 
         # pip requires filenames, not files.
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            tmpfile.write(str.encode('\n'.join(upgrade_package)))
+        with tempfile.NamedTemporaryFile(mode='wt') as tmpfile:
+            for package, version in upgrade_package_reqs:
+                line = '{}\n'.format(package) if not version else '{}=={}\n'.format(package, version)
+                tmpfile.write(line)
             tmpfile.flush()
 
             upgrade_candidates = list(
@@ -191,16 +200,19 @@ def cli(verbose, dry_run, pre, rebuild, find_links, index_url, extra_index_url,
                               .format(candidate.req.key))
                     sys.exit(2)
 
-                # we only want to process upgrades if the requirement is not pinned in the source file
                 constraint_candidate = existing_constraints[candidate.req.key]
-                if not constraint_candidate.req.specifier:
-                    upgraded_requirements[candidate.req.key] = constraint_candidate
+                if constraint_candidate.req.specifier:
+                    log.error("Asked to upgrade {} but it's pinned to a version in the source file. Quitting..."
+                              .format(candidate.req.key))
+                    sys.exit(2)
+                else:
+                    upgraded_requirements[candidate.req.key] = candidate
 
         existing_requirements.update(upgraded_requirements)
         constraints = existing_requirements.values()
 
     try:
-        repository = live_repository if upgrade or upgrade_package else local_repository
+        repository = local_repository if use_local_repo and not upgrade_package else live_repository
         resolver = Resolver(constraints, repository, prereleases=pre, clear_caches=rebuild)
         results = resolver.resolve()
     except PipToolsError as e:


### PR DESCRIPTION
The current behavior for `pip-compile --upgrade` updates all requirements. This becomes complicated for large `.in` files when that's not always the desired behavior.

This patch introduces a new flag, `--upgrade-package` which has the following features:

Upgrade only a specific package to the latest version:
```console
$ pip-compile --upgrade-package flask
```

Upgrade a specific package to a specific version:
```console
$ pip-compile --upgrade-package flask==0.10.1 
```

Upgrade multiple packages at a time, by passing in multiple arguments:
```console
$ pip-compile --upgrade-package flask==0.10.1 --upgrade-package werkzeug
```

Additional output was added when using the `--verbose` flag to list which packages were updated, and to which version.