### PR TITLE
improve --generate-hashes readability

### DIFF
--- a/piptools/writer.py
+++ b/piptools/writer.py
@@ -131,7 +131,9 @@ class OutputWriter(object):
         # Annotate what packages this package is required by
         required_by = reverse_dependencies.get(ireq.name.lower(), [])
         if required_by:
-            line = line.ljust(24)
-            annotation = ', '.join(sorted(required_by))
-            line += comment('  # via ' + annotation)
+            annotation = ", ".join(sorted(required_by))
+            line = "{:24}{}{}".format(
+                line,
+                " \\\n    " if ireq_hashes else "  ",
+                comment("# via " + annotation))
         return line

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -23,7 +23,7 @@ def test_format_requirement_annotation_editable(from_editable, writer):
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
-            '-e git+git://fake.org/x/y.git#egg=y' + comment('  # via xyz'))
+            '-e git+git://fake.org/x/y.git#egg=y  ' + comment('# via xyz'))
 
 
 def test_format_requirement_annotation(from_line, writer):
@@ -33,7 +33,7 @@ def test_format_requirement_annotation(from_line, writer):
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
-            'test==1.2               ' + comment('  # via xyz'))
+            'test==1.2                 ' + comment('# via xyz'))
 
 
 def test_format_requirement_annotation_case_sensitive(from_line, writer):
@@ -43,7 +43,7 @@ def test_format_requirement_annotation_case_sensitive(from_line, writer):
     assert (writer._format_requirement(ireq,
                                        reverse_dependencies,
                                        primary_packages=[]) ==
-            'Test==1.2               ' + comment('  # via xyz'))
+            'Test==1.2                 ' + comment('# via xyz'))
 
 
 def test_format_requirement_not_for_primary(from_line, writer):


### PR DESCRIPTION
by moving the annotations to the previous line w/ --generate-hashes

https://github.com/nvie/pip-tools/pull/383#issuecomment-252093933